### PR TITLE
Workloads: Refactor and tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-openapi/strfmt v0.20.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.2.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jakub-dzon/k4e-operator v0.0.0-20211007063427-678c7225ae78
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.16.0

--- a/internal/heartbeat/heartbeat_test.go
+++ b/internal/heartbeat/heartbeat_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Heartbeat", func() {
 			err := hb.Update(cfg)
 
 			// then
-			Expect(err).NotTo(HaveOccurred(), "Cannot update ticker")
+			Expect(err).NotTo(HaveOccurred())
 			Expect(hb.HasStarted()).To(BeTrue())
 		})
 
@@ -124,7 +124,7 @@ var _ = Describe("Heartbeat", func() {
 			err := hb.Update(cfg)
 
 			// then
-			Expect(err).NotTo(HaveOccurred(), "Cannot update ticker")
+			Expect(err).NotTo(HaveOccurred())
 			Expect(hb.HasStarted()).To(BeTrue())
 		})
 

--- a/internal/server/deviceserver.go
+++ b/internal/server/deviceserver.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+
 	"git.sr.ht/~spc/go-log"
 	configuration2 "github.com/jakub-dzon/k4e-device-worker/internal/configuration"
 	registration2 "github.com/jakub-dzon/k4e-device-worker/internal/registration"
@@ -12,13 +13,13 @@ import (
 
 type deviceServer struct {
 	pb.UnimplementedWorkerServer
-	configManager *configuration2.Manager
+	configManager       *configuration2.Manager
 	registrationManager *registration2.Registration
 }
 
 func NewDeviceServer(configManager *configuration2.Manager, registrationManager *registration2.Registration) *deviceServer {
 	return &deviceServer{
-		configManager: configManager,
+		configManager:       configManager,
 		registrationManager: registrationManager,
 	}
 }

--- a/internal/workload/manager.go
+++ b/internal/workload/manager.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/jakub-dzon/k4e-device-worker/internal/volumes"
 
 	"git.sr.ht/~spc/go-log"
@@ -82,24 +83,28 @@ func (w *WorkloadManager) GetExportedHostPath(workloadName string) string {
 func (w *WorkloadManager) Update(configuration models.DeviceConfigurationMessage) error {
 	w.managementLock.Lock()
 	defer w.managementLock.Unlock()
-
+	var errors error
 	if w.deregistered {
 		log.Info("Deregistration was finished, no need to update anymore")
-		return nil
+		return errors
 	}
+
 	configuredWorkloadNameSet := make(map[string]struct{})
 	for _, workload := range configuration.Workloads {
 		log.Tracef("Deploying workload: %s", workload.Name)
 		configuredWorkloadNameSet[workload.Name] = struct{}{}
-		// TODO: change error handling from fail fast to best effort (deploy as many workloads as possible)
+
 		pod, err := w.toPod(workload)
 		if err != nil {
-			return err
+			errors = multierror.Append(errors, fmt.Errorf(
+				"cannot convert workload '%s' to pod: %s", workload.Name, err))
+			continue
 		}
 		manifestPath := w.getManifestPath(pod.Name)
 		podYaml, err := w.toPodYaml(pod)
 		if err != nil {
-			return nil
+			errors = multierror.Append(errors, fmt.Errorf("cannot create pod's Yaml: %s", err))
+			continue
 		}
 		if !w.podModified(manifestPath, podYaml) {
 			log.Tracef("Pod '%s' definition is unchanged (%s)", workload.Name, manifestPath)
@@ -107,25 +112,31 @@ func (w *WorkloadManager) Update(configuration models.DeviceConfigurationMessage
 		}
 		err = w.storeManifest(manifestPath, podYaml)
 		if err != nil {
-			return err
+			errors = multierror.Append(errors, fmt.Errorf(
+				"cannot store manifest for workload '%s': %s", workload.Name, err))
+			continue
 		}
 
 		err = w.workloads.Remove(workload.Name)
 		if err != nil {
 			log.Errorf("Error removing workload: %v", err)
-			return err
+			errors = multierror.Append(errors, fmt.Errorf("error removing workload %s: %s", workload.Name, err))
+			continue
 		}
 		err = w.workloads.Run(pod, manifestPath)
 		if err != nil {
 			log.Errorf("Cannot run workload: %v", err)
-			return err
+			errors = multierror.Append(errors, fmt.Errorf(
+				"cannot run workload '%s': %s", workload.Name, err))
+			continue
 		}
 	}
 
 	deployedWorkloadByName, err := w.indexWorkloads()
 	if err != nil {
 		log.Errorf("Cannot get deployed workloads: %v", err)
-		return err
+		errors = multierror.Append(errors, fmt.Errorf("cannot get deployed workloads: %s", err))
+		return errors
 	}
 	// Remove any workloads that don't correspond to the configured ones
 	for name := range deployedWorkloadByName {
@@ -135,12 +146,12 @@ func (w *WorkloadManager) Update(configuration models.DeviceConfigurationMessage
 			err := os.Remove(manifestPath)
 			if err != nil {
 				if !os.IsNotExist(err) {
-					return err
+					errors = multierror.Append(errors, fmt.Errorf("cannot remove existing manifest workload: %s", err))
 				}
 			}
 
 			if err := w.workloads.Remove(name); err != nil {
-				return err
+				errors = multierror.Append(errors, fmt.Errorf("cannot remove stale workload name='%s': %s", name, err))
 			}
 			log.Infof("Workload %s removed", name)
 		}
@@ -149,7 +160,7 @@ func (w *WorkloadManager) Update(configuration models.DeviceConfigurationMessage
 	if configuration.WorkloadsMonitoringInterval > 0 {
 		w.ticker.Reset(time.Duration(configuration.WorkloadsMonitoringInterval))
 	}
-	return nil
+	return errors
 }
 
 func (w *WorkloadManager) initTicker(periodSeconds int64) {

--- a/internal/workload/manager_test.go
+++ b/internal/workload/manager_test.go
@@ -1,0 +1,289 @@
+package workload_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-multierror"
+	"github.com/jakub-dzon/k4e-device-worker/internal/workload"
+	api "github.com/jakub-dzon/k4e-device-worker/internal/workload/api"
+	"github.com/jakub-dzon/k4e-operator/models"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Manager", func() {
+
+	var (
+		datadir   string
+		mockCtrl  *gomock.Controller
+		wkManager *workload.WorkloadManager
+		wkwMock   *workload.MockWorkloadWrapper
+		err       error
+	)
+
+	BeforeEach(func() {
+		datadir, err = ioutil.TempDir("", "worloadTest")
+		Expect(err).ToNot(HaveOccurred())
+
+		mockCtrl = gomock.NewController(GinkgoT())
+		wkwMock = workload.NewMockWorkloadWrapper(mockCtrl)
+
+		wkwMock.EXPECT().Init().Return(nil).AnyTimes()
+		wkManager, err = workload.NewWorkloadManagerWithParams(datadir, wkwMock)
+		Expect(err).NotTo(HaveOccurred(), "Cannot start the Workload Manager")
+
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+		_ = os.Remove(datadir)
+	})
+
+	Context("NewWorkloadManagerWithParams", func() {
+		// @INFO: Other rules/creation correctly is part of the BeforeEach
+
+		It("Testing invalid datadir", func() {
+
+			// given
+			datadir, err = ioutil.TempDir("", "worloadTest")
+			err = os.Chmod(datadir, 0444)
+			Expect(err).NotTo(HaveOccurred())
+
+			// When
+			wkManager, err = workload.NewWorkloadManagerWithParams(datadir, wkwMock)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(wkManager).To(BeNil())
+		})
+	})
+
+	Context("Update", func() {
+		It("works as expected", func() {
+
+			// given
+			workloads := []*models.Workload{}
+
+			for i := 0; i < 10; i++ {
+				wkName := fmt.Sprintf("test%d", i)
+				workloads = append(workloads, &models.Workload{
+					Data:          &models.DataConfiguration{},
+					Name:          wkName,
+					Specification: "{}",
+				})
+				wkwMock.EXPECT().Remove(wkName).Times(1)
+			}
+
+			cfg := models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{Heartbeat: &models.HeartbeatConfiguration{PeriodSeconds: 1}},
+				DeviceID:      "",
+				Version:       "",
+				Workloads:     workloads,
+			}
+
+			wkwMock.EXPECT().List().AnyTimes()
+			wkwMock.EXPECT().Run(gomock.Any(), gomock.Any()).AnyTimes()
+
+			// when
+			err := wkManager.Update(cfg)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Workload Run failed", func() {
+			// given
+			cfg := models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{Heartbeat: &models.HeartbeatConfiguration{PeriodSeconds: 1}},
+				DeviceID:      "",
+				Version:       "",
+				Workloads: []*models.Workload{{
+					Data:          &models.DataConfiguration{},
+					Name:          "test",
+					Specification: "{}",
+				}},
+			}
+
+			wkwMock.EXPECT().List().AnyTimes()
+			wkwMock.EXPECT().Remove("test").AnyTimes()
+			wkwMock.EXPECT().Run(gomock.Any(), gomock.Any()).Return(fmt.Errorf("Cannot run workload")).Times(1)
+
+			// when
+			err := wkManager.Update(cfg)
+			merr, _ := err.(*multierror.Error)
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(merr.WrappedErrors()).To(HaveLen(1))
+		})
+
+		It("Cannot remove existing workload", func() {
+			// given
+			cfg := models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{Heartbeat: &models.HeartbeatConfiguration{PeriodSeconds: 1}},
+				DeviceID:      "",
+				Version:       "",
+				Workloads: []*models.Workload{{
+					Data:          &models.DataConfiguration{},
+					Name:          "test",
+					Specification: "{}",
+				}},
+			}
+
+			wkwMock.EXPECT().List().AnyTimes()
+			wkwMock.EXPECT().Remove("test").Return(fmt.Errorf("Cannot run workload")).Times(1)
+			wkwMock.EXPECT().Run(gomock.Any(), gomock.Any()).Times(0)
+
+			err := wkManager.Update(cfg)
+			merr, _ := err.(*multierror.Error)
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(merr.WrappedErrors()).To(HaveLen(1))
+		})
+
+		It("Some workloads failed", func() {
+			// So make sure that all worksloads tried to be executed, even if one
+			// failed.
+
+			// given
+			cfg := models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{Heartbeat: &models.HeartbeatConfiguration{PeriodSeconds: 1}},
+				DeviceID:      "",
+				Version:       "",
+				Workloads: []*models.Workload{
+					{
+						Data:          &models.DataConfiguration{},
+						Name:          "test",
+						Specification: "{}",
+					},
+					{
+						Data:          &models.DataConfiguration{},
+						Name:          "testB",
+						Specification: "{}",
+					},
+				},
+			}
+
+			wkwMock.EXPECT().List().AnyTimes()
+			wkwMock.EXPECT().Remove("test").AnyTimes()
+			wkwMock.EXPECT().Run(gomock.Any(), getManifest(datadir, "test")).Return(fmt.Errorf("Cannot run workload")).Times(1)
+
+			wkwMock.EXPECT().Remove("testB").AnyTimes()
+			wkwMock.EXPECT().Run(gomock.Any(), getManifest(datadir, "testB")).Return(nil).Times(1)
+
+			// when
+			err := wkManager.Update(cfg)
+			merr, _ := err.(*multierror.Error)
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(merr.WrappedErrors()).To(HaveLen(1))
+		})
+
+		It("staled workload got deleted if it's not in the config", func() {
+			// given
+			cfg := models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{Heartbeat: &models.HeartbeatConfiguration{PeriodSeconds: 1}},
+				DeviceID:      "",
+				Version:       "",
+				Workloads: []*models.Workload{
+					{
+						Data:          &models.DataConfiguration{},
+						Name:          "test",
+						Specification: "{}",
+					},
+					{
+						Data:          &models.DataConfiguration{},
+						Name:          "testB",
+						Specification: "{}",
+					},
+				},
+			}
+
+			currentWorkloads := []api.WorkloadInfo{
+				{Id: "stale", Name: "stale", Status: "running"},
+			}
+			wkwMock.EXPECT().List().Return(currentWorkloads, nil).AnyTimes()
+
+			wkwMock.EXPECT().Remove("test").AnyTimes()
+			wkwMock.EXPECT().Remove("testB").AnyTimes()
+			wkwMock.EXPECT().Run(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+			wkwMock.EXPECT().Remove("stale").Times(1)
+
+			// when
+			err := wkManager.Update(cfg)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("staled workload cannot get deleted", func() {
+			// given
+			cfg := models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{Heartbeat: &models.HeartbeatConfiguration{PeriodSeconds: 1}},
+				DeviceID:      "",
+				Version:       "",
+				Workloads:     []*models.Workload{},
+			}
+
+			currentWorkloads := []api.WorkloadInfo{
+				{Id: "stale", Name: "stale", Status: "running"},
+			}
+			wkwMock.EXPECT().List().Return(currentWorkloads, nil).AnyTimes()
+
+			wkwMock.EXPECT().Remove("stale").Return(fmt.Errorf("invalid workload"))
+
+			// when
+			err := wkManager.Update(cfg)
+
+			// then
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("ListWorkloads", func() {
+		It("Return the list correctly", func() {
+
+			// given
+			currentWorkloads := []api.WorkloadInfo{
+				{Id: "foo", Name: "foo", Status: "running"},
+			}
+			wkwMock.EXPECT().List().Return(currentWorkloads, nil).AnyTimes()
+
+			// when
+
+			list, err := wkManager.ListWorkloads()
+
+			// then
+
+			Expect(list).To(Equal(currentWorkloads))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Return error correctly", func() {
+
+			// given
+			currentWorkloads := []api.WorkloadInfo{}
+			wkwMock.EXPECT().List().Return(currentWorkloads, fmt.Errorf("Invalid")).AnyTimes()
+
+			// when
+
+			list, err := wkManager.ListWorkloads()
+
+			// then
+
+			Expect(list).To(Equal(currentWorkloads))
+			Expect(err).To(HaveOccurred())
+		})
+
+	})
+})
+
+func getManifest(datadir string, workloadName string) string {
+	return fmt.Sprintf("%s/manifests/%s.yaml", datadir, workloadName)
+}

--- a/internal/workload/workload_suite_test.go
+++ b/internal/workload/workload_suite_test.go
@@ -1,0 +1,13 @@
+package workload_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestWorkload(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Workload Suite")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -440,6 +440,7 @@ github.com/gorilla/schema
 # github.com/hashicorp/errwrap v1.0.0
 github.com/hashicorp/errwrap
 # github.com/hashicorp/go-multierror v1.1.1
+## explicit
 github.com/hashicorp/go-multierror
 # github.com/hpcloud/tail v1.0.0
 github.com/hpcloud/tail


### PR DESCRIPTION
Workload Manager was not tested. Also, some features were not complete,
so this commits changes the following:

- `Observer.Update` interface now returns an array of errors instead of
  a simple error. Some workloads can work, others cannot.
- Added test for `workload.Manager` where almost all important cases are
  covered.
  
Fix ECOPROJECT-290

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>