### PR TITLE
Makefile: fix Gingko

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export GOFLAGS=-mod=vendor -tags=containers_image_openpgp
 
 test-tools:
 ifeq (, $(shell which ginkgo))
-	go get github.com/onsi/ginkgo/ginkgo
+	GO111MODULE=off go get github.com/onsi/ginkgo/ginkgo
 endif
 
 


### PR DESCRIPTION
Ginkgo got updated today, and CI runs started to failed because the
version mismatch:

```
Run make test
go get github.com/onsi/ginkgo/ginkgo
go: downloading github.com/onsi/ginkgo v1.16.5
go: downloading github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0
go: downloading golang.org/x/tools v0.1.1
go: downloading github.com/nxadm/tail v1.4.8
go: downloading golang.org/x/sys v0.0.0-20210510120138-977fb7262007
go: downloading gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: downloading github.com/fsnotify/fsnotify v1.4.9
go get: upgraded github.com/onsi/ginkgo v1.16.4 => v1.16.5
ginkgo -r ./internal/* ./cmd/*
Failed to compile heartbeat:

go: inconsistent vendoring in /home/runner/work/k4e-device-worker/k4e-device-worker:
make: *** [Makefile:22: test] Error 1
	github.com/onsi/ginkgo@v1.16.5: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/onsi/ginkgo@v1.16.4: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod

	To ignore the vendor directory, use -mod=readonly or -mod=mod.
	To sync the vendor directory, run:
		go mod vendor

Ginkgo ran 1 suite in 51.203132ms
Test Suite Failed
```

https://github.com/jakub-dzon/k4e-device-worker/pull/32/checks?check_run_id=3862751049

To avoid this kind of issue, installing Ginkgo globally, so does not
crash with vendor.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>