### PR TITLE
Metrics: Added allowlist filtering

### DIFF
--- a/internal/metrics/daemon.go
+++ b/internal/metrics/daemon.go
@@ -147,8 +147,7 @@ func (tg *TargetMetric) Run(ctx context.Context) model.Vector {
 //go:generate mockgen -package=metrics -destination=mock_daemon.go . MetricsDaemon
 type MetricsDaemon interface {
 	Start()
-	AddTarget(targetName string, urls []string, interval time.Duration)
-	AddFilteredTarget(targetName string, urls []string, interval time.Duration, allowList SampleFilter)
+	AddTarget(targetName string, urls []string, interval time.Duration, allowList SampleFilter)
 	DeleteTarget(targetName string)
 }
 
@@ -191,8 +190,8 @@ func (md *metricsDaemon) startTarget(target *TargetMetric) {
 	go target.Start()
 }
 
-// AddFilteredTarget adds a metrics scraping target with filtering
-func (md *metricsDaemon) AddFilteredTarget(targetName string, urls []string, interval time.Duration, allowList SampleFilter) {
+// AddTarget adds a metrics scraping target with filtering
+func (md *metricsDaemon) AddTarget(targetName string, urls []string, interval time.Duration, allowList SampleFilter) {
 	target := NewTargetMetric(targetName, interval, urls, md.store, allowList)
 	log.Debugf("added target '%v' with the following urls: '%+v", targetName, urls)
 
@@ -203,11 +202,6 @@ func (md *metricsDaemon) AddFilteredTarget(targetName string, urls []string, int
 	defer md.lock.Unlock()
 	md.targets[targetName] = target
 	md.startTarget(target)
-}
-
-// AddTarget adds a metrics scraping target
-func (md *metricsDaemon) AddTarget(targetName string, urls []string, interval time.Duration) {
-	md.AddFilteredTarget(targetName, urls, interval, &PermissiveAllowList{})
 }
 
 // DeleteTarget deletes a target from getting metrics.

--- a/internal/metrics/daemon_test.go
+++ b/internal/metrics/daemon_test.go
@@ -2,10 +2,11 @@ package metrics_test
 
 import (
 	"fmt"
-	"github.com/project-flotta/flotta-operator/models"
 	"net/http"
 	"net/http/httptest"
 	"time"
+
+	"github.com/project-flotta/flotta-operator/models"
 
 	gomock "github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -127,7 +128,7 @@ var _ = Describe("Daemon", func() {
 			daemon := metrics.NewMetricsDaemon(metrics.NewMockAPI(mockCtrl))
 
 			// when
-			daemon.AddTarget("wrk1", []string{"http://192.168.1.1:8080"}, time.Second)
+			daemon.AddTarget("wrk1", []string{"http://192.168.1.1:8080"}, time.Second, &metrics.PermissiveAllowList{})
 
 			// then
 			targets := daemon.GetTargets()
@@ -141,9 +142,9 @@ var _ = Describe("Daemon", func() {
 			daemon := metrics.NewMetricsDaemon(metrics.NewMockAPI(mockCtrl))
 
 			// when
-			daemon.AddTarget("wrk1", []string{"http://192.168.1.1:8080"}, time.Second)
-			daemon.AddTarget("wrk2", []string{"http://192.168.1.1:8080"}, time.Second)
-			daemon.AddTarget("wrk3", []string{"http://192.168.1.1:8080"}, time.Second)
+			daemon.AddTarget("wrk1", []string{"http://192.168.1.1:8080"}, time.Second, &metrics.PermissiveAllowList{})
+			daemon.AddTarget("wrk2", []string{"http://192.168.1.1:8080"}, time.Second, &metrics.PermissiveAllowList{})
+			daemon.AddTarget("wrk3", []string{"http://192.168.1.1:8080"}, time.Second, &metrics.PermissiveAllowList{})
 			daemon.DeleteTarget("wrk2")
 
 			// then

--- a/internal/metrics/mock_daemon.go
+++ b/internal/metrics/mock_daemon.go
@@ -34,28 +34,16 @@ func (m *MockMetricsDaemon) EXPECT() *MockMetricsDaemonMockRecorder {
 	return m.recorder
 }
 
-// AddFilteredTarget mocks base method.
-func (m *MockMetricsDaemon) AddFilteredTarget(arg0 string, arg1 []string, arg2 time.Duration, arg3 SampleFilter) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddFilteredTarget", arg0, arg1, arg2, arg3)
-}
-
-// AddFilteredTarget indicates an expected call of AddFilteredTarget.
-func (mr *MockMetricsDaemonMockRecorder) AddFilteredTarget(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddFilteredTarget", reflect.TypeOf((*MockMetricsDaemon)(nil).AddFilteredTarget), arg0, arg1, arg2, arg3)
-}
-
 // AddTarget mocks base method.
-func (m *MockMetricsDaemon) AddTarget(arg0 string, arg1 []string, arg2 time.Duration) {
+func (m *MockMetricsDaemon) AddTarget(arg0 string, arg1 []string, arg2 time.Duration, arg3 SampleFilter) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddTarget", arg0, arg1, arg2)
+	m.ctrl.Call(m, "AddTarget", arg0, arg1, arg2, arg3)
 }
 
 // AddTarget indicates an expected call of AddTarget.
-func (mr *MockMetricsDaemonMockRecorder) AddTarget(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockMetricsDaemonMockRecorder) AddTarget(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTarget", reflect.TypeOf((*MockMetricsDaemon)(nil).AddTarget), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTarget", reflect.TypeOf((*MockMetricsDaemon)(nil).AddTarget), arg0, arg1, arg2, arg3)
 }
 
 // DeleteTarget mocks base method.

--- a/internal/metrics/system.go
+++ b/internal/metrics/system.go
@@ -1,10 +1,11 @@
 package metrics
 
 import (
-	"git.sr.ht/~spc/go-log"
 	"reflect"
 	"sync/atomic"
 	"time"
+
+	"git.sr.ht/~spc/go-log"
 
 	"github.com/project-flotta/flotta-device-worker/internal/configuration"
 	"github.com/project-flotta/flotta-device-worker/internal/service"
@@ -63,7 +64,7 @@ func (sm *SystemMetrics) Update(config models.DeviceConfigurationMessage) error 
 		sm.daemon.DeleteTarget(systemTargetName)
 	} else {
 		filter := getSampleFilter(newConfiguration.AllowList)
-		sm.daemon.AddFilteredTarget(systemTargetName, []string{NodeExporterMetricsEndpoint}, time.Duration(newConfiguration.Interval)*time.Second, filter)
+		sm.daemon.AddTarget(systemTargetName, []string{NodeExporterMetricsEndpoint}, time.Duration(newConfiguration.Interval)*time.Second, filter)
 	}
 
 	sm.latestConfig.Store(&newConfiguration)

--- a/internal/metrics/system_test.go
+++ b/internal/metrics/system_test.go
@@ -2,13 +2,14 @@ package metrics_test
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/project-flotta/flotta-device-worker/internal/metrics"
 	"github.com/project-flotta/flotta-device-worker/internal/service"
 	"github.com/project-flotta/flotta-operator/models"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"time"
 )
 
 var _ = Describe("System", func() {
@@ -56,7 +57,7 @@ var _ = Describe("System", func() {
 
 	It("should add node_exporter endpoint for scraping at init: default configuration", func() {
 		// given
-		daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+		daemonMock.EXPECT().AddTarget(gomock.Any(),
 			gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 			gomock.Eq(time.Second*time.Duration(metrics.DefaultSystemMetricsScrapingInterval)),
 			gomock.Eq(defaultFilter)).
@@ -75,7 +76,7 @@ var _ = Describe("System", func() {
 
 	It("should add node_exporter endpoint for scraping at init: custom configuration", func() {
 		// given
-		daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+		daemonMock.EXPECT().AddTarget(gomock.Any(),
 			gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 			gomock.Eq(time.Second*time.Duration(duration)),
 			gomock.Eq(customFilter))
@@ -102,7 +103,7 @@ var _ = Describe("System", func() {
 				},
 			},
 		}
-		daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+		daemonMock.EXPECT().AddTarget(gomock.Any(),
 			gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 			gomock.Eq(time.Second*time.Duration(metrics.DefaultSystemMetricsScrapingInterval)),
 			gomock.Eq(customFilter))
@@ -121,7 +122,7 @@ var _ = Describe("System", func() {
 
 	It("should not re-add node_exporter endpoint for scraping when default configuration is used on init and in update", func() {
 		// given
-		daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+		daemonMock.EXPECT().AddTarget(gomock.Any(),
 			gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 			gomock.Eq(time.Second*time.Duration(metrics.DefaultSystemMetricsScrapingInterval)),
 			gomock.Eq(defaultFilter)).
@@ -143,7 +144,7 @@ var _ = Describe("System", func() {
 
 	It("should not re-add node_exporter endpoint for scraping when default configuration is used repeatedly in update", func() {
 		// given
-		daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+		daemonMock.EXPECT().AddTarget(gomock.Any(),
 			gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 			gomock.Eq(time.Second*time.Duration(metrics.DefaultSystemMetricsScrapingInterval)),
 			gomock.Eq(defaultFilter)).
@@ -167,7 +168,7 @@ var _ = Describe("System", func() {
 
 	It("should not re-add node_exporter endpoint for scraping when same custom configuration is used on init and in update", func() {
 		// given
-		daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+		daemonMock.EXPECT().AddTarget(gomock.Any(),
 			gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 			gomock.Eq(time.Second*time.Duration(duration)),
 			gomock.Eq(customFilter)).
@@ -192,7 +193,7 @@ var _ = Describe("System", func() {
 
 	It("should not re-add node_exporter endpoint for scraping when same custom configuration is used repeatedly in update", func() {
 		// given
-		daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+		daemonMock.EXPECT().AddTarget(gomock.Any(),
 			gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 			gomock.Eq(time.Second*time.Duration(duration)),
 			gomock.Eq(customFilter)).
@@ -215,13 +216,13 @@ var _ = Describe("System", func() {
 
 	It("should re-add node_exporter endpoint for scraping when configuration changes from default to custom", func() {
 		// given
-		daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+		daemonMock.EXPECT().AddTarget(gomock.Any(),
 			gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 			gomock.Eq(time.Second*time.Duration(duration)),
 			gomock.Eq(customFilter)).
 			Times(1).
 			After(
-				daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+				daemonMock.EXPECT().AddTarget(gomock.Any(),
 					gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 					gomock.Eq(time.Second*time.Duration(metrics.DefaultSystemMetricsScrapingInterval)),
 					gomock.Eq(defaultFilter)).
@@ -244,13 +245,13 @@ var _ = Describe("System", func() {
 
 	It("should re-add node_exporter endpoint for scraping when configuration changes from custom to default", func() {
 		// given
-		daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+		daemonMock.EXPECT().AddTarget(gomock.Any(),
 			gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 			gomock.Eq(time.Second*time.Duration(metrics.DefaultSystemMetricsScrapingInterval)),
 			gomock.Eq(defaultFilter)).
 			Times(1).
 			After(
-				daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+				daemonMock.EXPECT().AddTarget(gomock.Any(),
 					gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 					gomock.Eq(time.Second*time.Duration(duration)),
 					gomock.Eq(customFilter)).
@@ -375,7 +376,7 @@ var _ = Describe("System", func() {
 	It("should disable node_exporter at update", func() {
 		// given
 		daemonMock.EXPECT().DeleteTarget("system").After(
-			daemonMock.EXPECT().AddFilteredTarget(gomock.Any(),
+			daemonMock.EXPECT().AddTarget(gomock.Any(),
 				gomock.Eq([]string{metrics.NodeExporterMetricsEndpoint}),
 				gomock.Eq(time.Second*time.Duration(metrics.DefaultSystemMetricsScrapingInterval)),
 				gomock.Eq(defaultFilter)).

--- a/internal/metrics/workload.go
+++ b/internal/metrics/workload.go
@@ -68,6 +68,11 @@ func (wrkM *WorkloadMetrics) WorkloadStarted(workloadName string, report []*podm
 			continue
 		}
 
+		var filter SampleFilter = &PermissiveAllowList{}
+		if cfg.Metrics.AllowList != nil {
+			filter = NewRestrictiveAllowList(cfg.Metrics.AllowList)
+		}
+
 		urls := []string{}
 		for _, workloadReport := range report {
 			urls = append(urls, getWorkloadUrls(workloadReport, cfg)...)
@@ -78,7 +83,11 @@ func (wrkM *WorkloadMetrics) WorkloadStarted(workloadName string, report []*podm
 			interval = cfg.Metrics.Interval
 		}
 		// log for this is part of the AddTarget function
-		wrkM.daemon.AddTarget(workload.Name, urls, time.Duration(interval)*time.Second)
+		wrkM.daemon.AddFilteredTarget(
+			workload.Name,
+			urls,
+			time.Duration(interval)*time.Second,
+			filter)
 	}
 }
 

--- a/internal/metrics/workload.go
+++ b/internal/metrics/workload.go
@@ -83,7 +83,7 @@ func (wrkM *WorkloadMetrics) WorkloadStarted(workloadName string, report []*podm
 			interval = cfg.Metrics.Interval
 		}
 		// log for this is part of the AddTarget function
-		wrkM.daemon.AddFilteredTarget(
+		wrkM.daemon.AddTarget(
 			workload.Name,
 			urls,
 			time.Duration(interval)*time.Second,

--- a/internal/metrics/workload_test.go
+++ b/internal/metrics/workload_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Workload", func() {
 			wrk.Update(cfg)
 
 			// then
-			daemonMock.EXPECT().AddFilteredTarget(
+			daemonMock.EXPECT().AddTarget(
 				"wrk1",
 				[]string{"http://192.168.1.1:9000/custom_metrics"},
 				50*time.Second,
@@ -140,7 +140,7 @@ var _ = Describe("Workload", func() {
 			wrk.Update(cfg)
 
 			// then
-			daemonMock.EXPECT().AddFilteredTarget(
+			daemonMock.EXPECT().AddTarget(
 				"wrk1",
 				[]string{"http://192.168.1.1:8888/c1/"},
 				50*time.Second,
@@ -185,7 +185,7 @@ var _ = Describe("Workload", func() {
 			wrk.Update(cfg)
 
 			// then
-			daemonMock.EXPECT().AddFilteredTarget(
+			daemonMock.EXPECT().AddTarget(
 				"wrk1",
 				[]string{"http://192.168.1.1:9000/", "http://192.168.1.2:8888/"},
 				50*time.Second,
@@ -231,7 +231,7 @@ var _ = Describe("Workload", func() {
 			wrk.Update(cfg)
 
 			// then
-			daemonMock.EXPECT().AddFilteredTarget(
+			daemonMock.EXPECT().AddTarget(
 				"wrk1",
 				[]string{"http://192.168.1.2:8888/c2/"},
 				50*time.Second,
@@ -276,7 +276,7 @@ var _ = Describe("Workload", func() {
 			wrk.Update(cfg)
 
 			// then
-			daemonMock.EXPECT().AddFilteredTarget(
+			daemonMock.EXPECT().AddTarget(
 				"wrk1",
 				[]string{"http://192.168.1.1:8888/c1/", "http://192.168.1.2:9000/custom_metrics", "http://192.168.1.3:8888/c3/"},
 				50*time.Second,
@@ -311,7 +311,7 @@ var _ = Describe("Workload", func() {
 			wrk.Update(cfg)
 
 			// then
-			daemonMock.EXPECT().AddFilteredTarget(
+			daemonMock.EXPECT().AddTarget(
 				"wrk1",
 				[]string{"http://192.168.1.1:9000/custom_metrics"},
 				50*time.Second,
@@ -345,7 +345,7 @@ var _ = Describe("Workload", func() {
 			wrk.Update(cfg)
 
 			// then
-			daemonMock.EXPECT().AddFilteredTarget(
+			daemonMock.EXPECT().AddTarget(
 				"wrk1",
 				[]string{"http://192.168.1.1:9000/custom_metrics"},
 				50*time.Second,


### PR DESCRIPTION
With this commit, users can define what metrics want to to retrieve
on workload level.

Related-to: https://github.com/project-flotta/flotta-operator/commit/5b67dd38215b6a110a6293c9ac35875e9417daa0
Fix: ECOPROJECT-495

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>