### PR TITLE
Metrics: Added more metrics on default allow-list

### DIFF
--- a/internal/metrics/allow-list.go
+++ b/internal/metrics/allow-list.go
@@ -33,7 +33,9 @@ func DefaultSystemAllowList() SampleFilter {
 		"node_memory_MemFree_bytes":      {},
 		"node_memory_MemTotal_bytes":     {},
 
-		"node_network_info": {},
+		"node_network_info":                 {},
+		"node_network_receive_bytes_total":  {},
+		"node_network_transmit_bytes_total": {},
 	}
 	// TODO: set defaults
 	return &RestrictiveAllowList{


### PR DESCRIPTION
By default, device-worker does not send any information about how many
network bandwidth is using, with this change will report the following
metrics:

```
node_network_receive_bytes_total
node_network_transmit_bytes_total
```

Fix: ECOPROJECT-495

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>