### PR TITLE
Workload: Fix error messages

### DIFF
--- a/internal/workload/wrapper.go
+++ b/internal/workload/wrapper.go
@@ -65,20 +65,20 @@ func NewWorkload(p podman.Podman, n network.Netfilter, m mapping.MappingReposito
 func newWorkloadInstance(configDir string, monitoringInterval uint) (*Workload, error) {
 	newPodman, err := podman.NewPodman()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("workload cannot initialize podman manager: %w", err)
 	}
 	netfilter, err := network.NewNetfilter()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("workload cannot initialize netfilter manager: %w", err)
 	}
 	mappingRepository, err := mapping.NewMappingRepository(configDir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("workload cannot initialize mapping repository: %w", err)
 	}
 
 	serviceManager, err := service.NewSystemdManager(configDir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("workload cannot initialize systemd manager: %w", err)
 	}
 
 	ww := &Workload{


### PR DESCRIPTION
Small change on workload wrapper to:

- Send a valid error message to the user, instead cannot parse JSON.
- Unmarshal JSON as struct, due to is not valid parsing JSON to a
  interface.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>