### PR TITLE
Collect Workload logs

### DIFF
--- a/cmd/device-worker/main.go
+++ b/cmd/device-worker/main.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/project-flotta/flotta-device-worker/internal/logs"
 	"github.com/project-flotta/flotta-device-worker/internal/metrics"
 
 	configuration2 "github.com/project-flotta/flotta-device-worker/internal/configuration"
@@ -122,6 +123,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("cannot start Workload Manager. DeviceID: %s; err: %v", deviceId, err)
 	}
+
+	logsWrapper := logs.NewWorkloadsLogsTarget(wl)
+	configManager.RegisterObserver(logsWrapper)
+	wl.RegisterObserver(logsWrapper)
 	configManager.RegisterObserver(wl)
 	wl.RegisterObserver(workloadMetricWatcher)
 

--- a/internal/logs/log_container.go
+++ b/internal/logs/log_container.go
@@ -1,0 +1,94 @@
+package logs
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	elapsedTime = 100 * time.Millisecond
+)
+
+type LogEntry struct {
+	Time     time.Time
+	data     []byte
+	workload string
+}
+
+func NewLogEntry(data []byte, workload string) *LogEntry {
+	return &LogEntry{
+		data:     data,
+		Time:     time.Now(),
+		workload: workload,
+	}
+}
+
+func (l *LogEntry) Size() int {
+	return len(l.data)
+}
+
+func (l *LogEntry) String() string {
+	if l.data == nil {
+		return ""
+	}
+	return string(l.data)
+}
+
+func (l *LogEntry) GetWorkload() string {
+	return l.workload
+}
+
+type FIFOLog struct {
+	maxlen      int
+	data        []*LogEntry
+	lock        sync.Mutex
+	currentSize int
+}
+
+// NewFIFOLog returns a new FifoLog struct
+func NewFIFOLog(maxSize int) *FIFOLog {
+	return &FIFOLog{
+		data:   []*LogEntry{},
+		maxlen: maxSize,
+	}
+}
+
+// CurrentSize returns the buffer size.
+func (f *FIFOLog) CurrentSize() int {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	return f.currentSize
+}
+
+// Write fills the current buffer with the next LogEntry
+func (f *FIFOLog) Write(entry *LogEntry) error {
+	if entry == nil {
+		return errors.New("No log entry added")
+	}
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	// We have here a "soft" limit, current entry size can be bigger than
+	// f.maxlen but we only pass once.
+	if f.currentSize > f.maxlen {
+		return fmt.Errorf("Buffer is already full")
+	}
+	f.data = append(f.data, entry)
+	f.currentSize = f.currentSize + entry.Size()
+	return nil
+}
+
+// ReadLine reads the line and delete it from the current buffer.
+func (f *FIFOLog) ReadLine() (*LogEntry, error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if f.currentSize <= 0 {
+		return nil, nil
+	}
+	res := f.data[0]
+	f.data = f.data[1:]
+	f.currentSize = f.currentSize - res.Size()
+	return res, nil
+}

--- a/internal/logs/log_container_test.go
+++ b/internal/logs/log_container_test.go
@@ -1,0 +1,70 @@
+package logs_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/project-flotta/flotta-device-worker/internal/logs"
+)
+
+var _ = Describe("FifoLog", func() {
+
+	Context("Write", func() {
+
+		It("No entry", func() {
+
+			// given
+			fifolog := logs.NewFIFOLog(10)
+
+			// when
+			err := fifolog.Write(nil)
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(fifolog.CurrentSize()).To(Equal(0))
+		})
+
+		It("Size is bigger than expected", func() {
+
+			// given
+			fifolog := logs.NewFIFOLog(1)
+
+			err := fifolog.Write(logs.NewLogEntry([]byte("123"), "test"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fifolog.CurrentSize()).To(Equal(3))
+
+			// when
+			err = fifolog.Write(logs.NewLogEntry([]byte("a"), "test"))
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(fifolog.CurrentSize()).To(Equal(3))
+		})
+
+	})
+
+	Context("Readline", func() {
+		It("Reads and got deleted", func() {
+			// given
+			fifolog := logs.NewFIFOLog(1000)
+			for i := 0; i < 10; i++ {
+				err := fifolog.Write(logs.NewLogEntry([]byte(fmt.Sprintf("%d", i)), "test"))
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			// When
+			for i := 0; i < 10; i++ {
+				entry, err := fifolog.ReadLine()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(entry.String()).To(Equal(fmt.Sprintf("%d", i)))
+				Expect(entry.GetWorkload()).To(Equal("test"))
+			}
+			// then
+
+			entry, err := fifolog.ReadLine()
+			Expect(entry).To(BeNil())
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/internal/logs/logs_suite_test.go
+++ b/internal/logs/logs_suite_test.go
@@ -1,0 +1,13 @@
+package logs_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logs Suite")
+}

--- a/internal/logs/syslog_transport.go
+++ b/internal/logs/syslog_transport.go
@@ -1,0 +1,85 @@
+package logs
+
+import (
+	"errors"
+	"fmt"
+	"log/syslog"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	priority           = syslog.LOG_INFO
+	elapsedTimeOnError = 100 * time.Millisecond
+)
+
+// We implement this way to force timestamp with the original ones.
+type syslogTransport struct {
+	server   string
+	protocol string
+	hostname string
+	conn     net.Conn
+	lock     sync.Mutex // guards conn
+}
+
+func NewSyslogServer(server string, protocol string, deviceID string) (*syslogTransport, error) {
+	proto := "tcp"
+	if protocol != "" {
+		proto = protocol
+	}
+	syslogInstance := &syslogTransport{
+		server:   server,
+		protocol: proto,
+		hostname: deviceID,
+		lock:     sync.Mutex{},
+	}
+	err := syslogInstance.Init()
+	if err != nil {
+		return nil, err
+	}
+	return syslogInstance, nil
+}
+
+func (s *syslogTransport) Init() error {
+	var err error
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.conn, err = net.Dial(s.protocol, s.server)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (s *syslogTransport) WriteLog(logline *LogEntry) error {
+	s.lock.Lock()
+	hostname := s.hostname
+	s.lock.Unlock()
+
+	logEntry := fmt.Sprintf("<%d>%s %s %s[%d]: %s\n",
+		priority, logline.Time.Format(time.RFC3339), hostname,
+		logline.workload, os.Getpid(), logline.String())
+	return s.writeAndRetry(logEntry, 10)
+}
+
+func (s *syslogTransport) writeAndRetry(data string, retryTimes int) error {
+	if retryTimes < 0 {
+		return errors.New("cannot send message")
+	}
+
+	s.lock.Lock()
+	if s.conn != nil {
+		_, err := fmt.Fprintf(s.conn, "%s", data)
+		s.lock.Unlock()
+		if err != nil {
+			time.Sleep(elapsedTimeOnError)
+			return s.writeAndRetry(data, retryTimes-1)
+		}
+		return nil
+	}
+	s.lock.Unlock()
+	return s.writeAndRetry(data, retryTimes-1)
+}

--- a/internal/logs/transport.go
+++ b/internal/logs/transport.go
@@ -1,5 +1,9 @@
 package logs
 
+const (
+	SyslogTransport = "syslog"
+)
+
 type transport interface {
-	WriteLog(logline *LogEntry, workload string) error
+	WriteLog(logline *LogEntry) error
 }

--- a/internal/logs/transport.go
+++ b/internal/logs/transport.go
@@ -1,0 +1,5 @@
+package logs
+
+type transport interface {
+	WriteLog(logline *LogEntry, workload string) error
+}

--- a/internal/logs/workload.go
+++ b/internal/logs/workload.go
@@ -1,0 +1,201 @@
+package logs
+
+import (
+	"context"
+	"time"
+
+	"git.sr.ht/~spc/go-log"
+	"github.com/project-flotta/flotta-device-worker/internal/workload"
+	"github.com/project-flotta/flotta-device-worker/internal/workload/podman"
+	"github.com/project-flotta/flotta-operator/models"
+)
+
+type transportLog struct {
+	transport transport
+	log       *FIFOLog
+	cancel    context.CancelFunc
+}
+
+func (t *transportLog) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.cancel = cancel
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				entry, err := t.log.ReadLine()
+				if err != nil {
+					log.Error("error on read log info", err)
+				}
+				if entry == nil {
+					time.Sleep(elapsedTime)
+				} else {
+					err = t.transport.WriteLog(entry)
+					if err != nil {
+						// cannot send, pushed again to the queue.
+						err := t.log.Write(entry)
+						if err != nil {
+							log.Error("cannot return log entry to the buffer log after transport failed", err)
+						}
+					}
+				}
+			}
+		}
+	}()
+}
+
+func (t *transportLog) Stop() {
+	if t.cancel != nil {
+		t.cancel()
+	}
+}
+
+type WorkloadsLogsTarget struct {
+	deviceID        string
+	transports      map[string]transportLog
+	wwriter         map[string]*WorkloadWriter // key is the workload name
+	workloadsConfig map[string]string
+	workloadManager *workload.WorkloadManager
+}
+
+func NewWorkloadsLogsTarget(manager *workload.WorkloadManager) *WorkloadsLogsTarget {
+	return &WorkloadsLogsTarget{
+		transports:      map[string]transportLog{},
+		wwriter:         map[string]*WorkloadWriter{},
+		workloadsConfig: map[string]string{},
+		workloadManager: manager,
+	}
+}
+
+func (w *WorkloadsLogsTarget) GetCurrentTransports() []string {
+	res := []string{}
+	for key := range w.transports {
+		res = append(res, key)
+	}
+	return res
+}
+
+func (w *WorkloadsLogsTarget) GetCurrentWorkloads() []*WorkloadWriter {
+	res := []*WorkloadWriter{}
+	for _, val := range w.wwriter {
+		res = append(res, val)
+	}
+	return res
+}
+
+func (w *WorkloadsLogsTarget) deleteTargetTransport(name string) {
+	delete(w.transports, name)
+	for key, writer := range w.wwriter {
+		if writer.targetName != name {
+			continue
+		}
+		writer.Stop()
+		delete(w.wwriter, key)
+		log.Debugf("Stoping and removing log target transport '%s'", name)
+
+	}
+}
+
+func (w *WorkloadsLogsTarget) deleteWorkload(name string) {
+	workloadWriter, ok := w.wwriter[name]
+	if ok {
+		workloadWriter.Stop()
+		delete(w.wwriter, name)
+	}
+}
+
+func (w *WorkloadsLogsTarget) Init(config models.DeviceConfigurationMessage) error {
+	w.deviceID = config.DeviceID
+
+	err := w.Update(config)
+	if err != nil {
+		return err
+	}
+
+	workloads, err := w.workloadManager.ListWorkloads()
+	if err != nil {
+		log.Error("Logs: cannot get current list of workloads:", err)
+		return err
+	}
+
+	for _, wrk := range workloads {
+		w.WorkloadStarted(wrk.Name, nil)
+	}
+
+	return nil
+}
+
+func (w *WorkloadsLogsTarget) Update(config models.DeviceConfigurationMessage) error {
+	original_transports := w.GetCurrentTransports()
+	transports := map[string]transportLog{}
+
+	for key, val := range config.Configuration.LogCollection {
+		kind := val.Kind
+		switch kind {
+		case SyslogTransport:
+			transport, err := NewSyslogServer(val.SyslogConfig.Address, val.SyslogConfig.Protocol, w.deviceID)
+			if err != nil {
+				log.Errorf("Cannot add log transport to target: %s", err)
+				continue
+			}
+			tlog := transportLog{
+				transport: transport,
+				log:       NewFIFOLog(int(val.BufferSize * 1024)),
+			}
+			tlog.Start()
+			transports[key] = tlog
+			log.Debugf("Started log transport '%s'", key)
+		default:
+			log.Errorf("Cannot initialize log transport %s", kind)
+		}
+	}
+	// Delete leftovers trasnports if no longer exists
+	for i := range original_transports {
+		key := original_transports[i]
+		if _, ok := transports[key]; !ok {
+			w.deleteTargetTransport(key)
+		}
+	}
+	log.Debugf("Update log transports, number of tranports: %d", len(transports))
+	w.transports = transports
+
+	workloadsConfig := map[string]string{}
+	for _, workload := range config.Workloads {
+		if workload.LogCollection != "" {
+			workloadsConfig[workload.Name] = workload.LogCollection
+		}
+	}
+	w.workloadsConfig = workloadsConfig
+	return nil
+}
+
+func (w *WorkloadsLogsTarget) WorkloadRemoved(workloadName string) {
+	w.deleteWorkload(workloadName)
+}
+
+func (w *WorkloadsLogsTarget) WorkloadStarted(workloadName string, report []*podman.PodReport) {
+	// If target is present, just delete it because maybe is there any leftover
+	// and want to delete in case a restart.
+	w.deleteWorkload(workloadName)
+
+	targetTransport, ok := w.workloadsConfig[workloadName]
+	if !ok {
+		return
+	}
+
+	transport, ok := w.transports[targetTransport]
+	if !ok {
+		log.Errorf("Log transport '%s' cannot be found in this device", targetTransport)
+		return
+	}
+
+	writer := NewWorkloadWriter(workloadName, w.workloadManager)
+	writer.SetTarget(targetTransport, transport.log)
+	w.wwriter[workloadName] = writer
+	err := writer.Start()
+	if err != nil {
+		log.Error("Cannot start workload logs", err)
+	}
+}

--- a/internal/logs/workload_test.go
+++ b/internal/logs/workload_test.go
@@ -1,0 +1,324 @@
+package logs_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"net"
+	"os"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/project-flotta/flotta-device-worker/internal/logs"
+	"github.com/project-flotta/flotta-device-worker/internal/workload"
+	"github.com/project-flotta/flotta-device-worker/internal/workload/api"
+	"github.com/project-flotta/flotta-operator/models"
+)
+
+var _ = Describe("WorkloadsLogsTarget", func() {
+
+	var (
+		datadir   string
+		mockCtrl  *gomock.Controller
+		wkManager *workload.WorkloadManager
+		wkwMock   *workload.MockWorkloadWrapper
+		err       error
+		l         net.Listener
+	)
+
+	const (
+		deviceId = "foo"
+	)
+
+	BeforeEach(func() {
+		l, err = net.Listen("tcp", "127.0.0.1:10600")
+		Expect(err).ToNot(HaveOccurred())
+
+		datadir, err = ioutil.TempDir("", "worloadTest")
+		Expect(err).ToNot(HaveOccurred())
+
+		mockCtrl = gomock.NewController(GinkgoT())
+		wkwMock = workload.NewMockWorkloadWrapper(mockCtrl)
+
+		wkwMock.EXPECT().Init().Return(nil).AnyTimes()
+		wkManager, err = workload.NewWorkloadManagerWithParamsAndInterval(datadir, wkwMock, 2, deviceId)
+		Expect(err).NotTo(HaveOccurred(), "cannot start the Workload Manager")
+
+	})
+
+	AfterEach(func() {
+		l.Close()
+		mockCtrl.Finish()
+		_ = os.RemoveAll(datadir)
+	})
+
+	Context("Update", func() {
+		var (
+			work *logs.WorkloadsLogsTarget
+		)
+
+		BeforeEach(func() {
+			work = logs.NewWorkloadsLogsTarget(wkManager)
+		})
+
+		It("Create all targets", func() {
+			// given
+			config := models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{
+					LogCollection: map[string]models.LogsCollectionInformation{
+						"syslog": {
+							BufferSize: 10,
+							Kind:       "syslog",
+							SyslogConfig: &models.LogsCollectionInformationSyslogConfig{
+								Address:  "127.0.0.1:10600",
+								Protocol: "tcp",
+							},
+						},
+						"foo": {
+							BufferSize: 10,
+							Kind:       "syslog",
+							SyslogConfig: &models.LogsCollectionInformationSyslogConfig{
+								Address:  "127.0.0.1:10600",
+								Protocol: "tcp",
+							},
+						},
+					},
+				},
+				DeviceID:  deviceId,
+				Workloads: []*models.Workload{},
+			}
+			// when
+			err := work.Update(config)
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			transports := work.GetCurrentTransports()
+			Expect(transports).To(HaveLen(2))
+			Expect(transports).To(ContainElements("syslog", "foo"))
+
+		})
+
+		It("Leftover are deleted", func() {
+			// given
+			config := models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{
+					LogCollection: map[string]models.LogsCollectionInformation{
+						"syslog": {
+							BufferSize: 10,
+							Kind:       "syslog",
+							SyslogConfig: &models.LogsCollectionInformationSyslogConfig{
+								Address:  "127.0.0.1:10600",
+								Protocol: "tcp",
+							},
+						},
+						"foo": {
+							BufferSize: 10,
+							Kind:       "syslog",
+							SyslogConfig: &models.LogsCollectionInformationSyslogConfig{
+								Address:  "127.0.0.1:10600",
+								Protocol: "tcp",
+							},
+						},
+					},
+				},
+				DeviceID: deviceId,
+				Workloads: []*models.Workload{
+					{Name: "work1", LogCollection: "syslog"},
+					{Name: "work2", LogCollection: "foo"},
+				},
+			}
+
+			err := work.Update(config)
+			Expect(err).NotTo(HaveOccurred())
+			transports := work.GetCurrentTransports()
+			Expect(transports).To(HaveLen(2))
+			Expect(transports).To(ContainElements("syslog", "foo"))
+
+			// to check that workload is also removed if the target is remved
+			wkwMock.EXPECT().Logs("work1", gomock.Any()).Times(1)
+			wkwMock.EXPECT().Logs("work2", gomock.Any()).Times(1)
+			work.WorkloadStarted("work1", nil)
+			work.WorkloadStarted("work2", nil)
+			res := work.GetCurrentWorkloads()
+			Expect(res).To(HaveLen(2))
+
+			// when
+
+			config = models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{
+					LogCollection: map[string]models.LogsCollectionInformation{
+						"foo": {
+							BufferSize: 10,
+							Kind:       "syslog",
+							SyslogConfig: &models.LogsCollectionInformationSyslogConfig{
+								Address:  "127.0.0.1:10600",
+								Protocol: "tcp",
+							},
+						},
+					},
+				},
+				DeviceID:  deviceId,
+				Workloads: []*models.Workload{},
+			}
+			err = work.Update(config)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(work.GetCurrentTransports()).To(Equal([]string{"foo"}))
+
+			res = work.GetCurrentWorkloads()
+			Expect(res).To(HaveLen(1))
+		})
+
+		It("Invalid targets are not created", func() {
+			// given
+			config := models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{
+					LogCollection: map[string]models.LogsCollectionInformation{
+						"syslog": {
+							BufferSize: 10,
+							Kind:       "INVALID",
+							SyslogConfig: &models.LogsCollectionInformationSyslogConfig{
+								Address:  "127.0.0.1:10600",
+								Protocol: "tcp",
+							},
+						},
+					},
+				},
+				DeviceID:  deviceId,
+				Workloads: []*models.Workload{},
+			}
+			// when
+			err := work.Update(config)
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(work.GetCurrentTransports()).NotTo(Equal([]string{"foo"}))
+		})
+	})
+
+	Context("Workload is modified", func() {
+		var (
+			work   *logs.WorkloadsLogsTarget
+			config models.DeviceConfigurationMessage
+		)
+
+		BeforeEach(func() {
+			work = logs.NewWorkloadsLogsTarget(wkManager)
+
+			config = models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{
+					LogCollection: map[string]models.LogsCollectionInformation{
+						"syslog": {
+							BufferSize: 10,
+							Kind:       "syslog",
+							SyslogConfig: &models.LogsCollectionInformationSyslogConfig{
+								Address:  "127.0.0.1:10600",
+								Protocol: "tcp",
+							},
+						},
+					},
+				},
+				DeviceID:  deviceId,
+				Workloads: []*models.Workload{},
+			}
+		})
+
+		It("WorkloadStarted not present", func() {
+			// given
+			err := work.Update(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			// when
+			work.WorkloadStarted("InvalidWorkload", nil)
+			res := work.GetCurrentWorkloads()
+			// then
+			Expect(res).To(HaveLen(0))
+		})
+
+		It("Workload with invalid target", func() {
+			// given
+			config.Workloads = []*models.Workload{
+				{Name: "foo", LogCollection: "test"},
+			}
+			err := work.Update(config)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			// when
+			work.WorkloadStarted("foo", nil)
+			res := work.GetCurrentWorkloads()
+			// then
+			Expect(res).To(HaveLen(0))
+		})
+
+		It("Workload with valid target", func() {
+			// given
+			config.Workloads = []*models.Workload{
+				{Name: "foo", LogCollection: "syslog"},
+			}
+			err := work.Update(config)
+			Expect(err).NotTo(HaveOccurred())
+
+			wkwMock.EXPECT().Logs("foo", gomock.Any()).Times(1)
+
+			// when
+			work.WorkloadStarted("foo", nil)
+			res := work.GetCurrentWorkloads()
+
+			// then
+			Expect(res).To(HaveLen(1))
+
+			// Removed correctly
+			work.WorkloadRemoved("foo")
+			res = work.GetCurrentWorkloads()
+			Expect(res).To(HaveLen(0))
+		})
+	})
+
+	Context("Init", func() {
+		var (
+			work   *logs.WorkloadsLogsTarget
+			config models.DeviceConfigurationMessage
+		)
+
+		BeforeEach(func() {
+			work = logs.NewWorkloadsLogsTarget(wkManager)
+
+			config = models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{
+					LogCollection: map[string]models.LogsCollectionInformation{
+						"syslog": {
+							BufferSize: 10,
+							Kind:       "syslog",
+							SyslogConfig: &models.LogsCollectionInformationSyslogConfig{
+								Address:  "127.0.0.1:10600",
+								Protocol: "tcp",
+							},
+						},
+					},
+				},
+				DeviceID: deviceId,
+				Workloads: []*models.Workload{
+					{Name: "foo", LogCollection: "syslog"},
+				}}
+		})
+
+		It("Cannot retrieve workloads list", func() {
+			// given
+			wkwMock.EXPECT().List().Times(1).Return(nil, errors.New("test"))
+			// when
+			err := work.Init(config)
+			// then
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Started workloads logs", func() {
+			// given
+			wkwMock.EXPECT().List().Times(1).Return([]api.WorkloadInfo{{Name: "foo"}}, nil)
+			wkwMock.EXPECT().Logs("foo", gomock.Any()).Times(1)
+			// when
+			err := work.Init(config)
+			// then
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/internal/logs/workload_writer.go
+++ b/internal/logs/workload_writer.go
@@ -1,0 +1,60 @@
+package logs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/project-flotta/flotta-device-worker/internal/workload"
+)
+
+type WorkloadWriter struct {
+	workloadName string
+	cancel       context.CancelFunc
+	target       *FIFOLog
+	targetName   string
+	manager      *workload.WorkloadManager
+}
+
+func NewWorkloadWriter(workload string, manager *workload.WorkloadManager) *WorkloadWriter {
+	res := &WorkloadWriter{
+		workloadName: workload,
+		manager:      manager,
+	}
+	return res
+}
+
+func (ww *WorkloadWriter) SetTarget(name string, target *FIFOLog) {
+	ww.target = target
+	ww.targetName = name
+}
+
+func (ww *WorkloadWriter) Write(data []byte) (n int, err error) {
+	entry := NewLogEntry(data, ww.workloadName)
+	if ww.target == nil {
+		return 0, fmt.Errorf("cannot write to target, no buffer is defined")
+	}
+	err = ww.target.Write(entry)
+	if err != nil {
+		return 0, fmt.Errorf("cannot write to target: %v", err)
+	}
+	return len(data), nil
+}
+
+// Stop writer.
+func (ww *WorkloadWriter) Stop() {
+	if ww.cancel == nil {
+		return
+	}
+	ww.cancel()
+}
+
+// Start writer.
+func (ww *WorkloadWriter) Start() error {
+	cancel, err := ww.manager.Logs(ww.workloadName, ww)
+	ww.cancel = cancel
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/logs/workload_writer_test.go
+++ b/internal/logs/workload_writer_test.go
@@ -1,0 +1,127 @@
+package logs_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/project-flotta/flotta-device-worker/internal/logs"
+	"github.com/project-flotta/flotta-device-worker/internal/workload"
+)
+
+var _ = Describe("WorkloadWrite", func() {
+
+	var (
+		datadir   string
+		mockCtrl  *gomock.Controller
+		wkManager *workload.WorkloadManager
+		wkwMock   *workload.MockWorkloadWrapper
+		err       error
+		target    *logs.FIFOLog
+	)
+
+	const (
+		deviceId = "foo"
+	)
+
+	BeforeEach(func() {
+		datadir, err = ioutil.TempDir("", "worloadTest")
+		Expect(err).ToNot(HaveOccurred())
+
+		mockCtrl = gomock.NewController(GinkgoT())
+		wkwMock = workload.NewMockWorkloadWrapper(mockCtrl)
+
+		wkwMock.EXPECT().Init().Return(nil).AnyTimes()
+		wkManager, err = workload.NewWorkloadManagerWithParamsAndInterval(datadir, wkwMock, 2, deviceId)
+		Expect(err).NotTo(HaveOccurred(), "cannot start the Workload Manager")
+		target = logs.NewFIFOLog(5)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+		_ = os.RemoveAll(datadir)
+	})
+
+	Context("Write", func() {
+
+		It("No target defined", func() {
+			// given
+			writer := logs.NewWorkloadWriter("workload", wkManager)
+			// when
+			n, err := writer.Write([]byte("foo"))
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(n).To(Equal(0))
+		})
+
+		It("Target is defined correctly", func() {
+
+			// given
+			writer := logs.NewWorkloadWriter("workload", wkManager)
+			writer.SetTarget("test", target)
+
+			// when
+			n, err := writer.Write([]byte("foo"))
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(3))
+		})
+
+		It("Target failed to write", func() {
+
+			// given
+			writer := logs.NewWorkloadWriter("workload", wkManager)
+			writer.SetTarget("test", target)
+
+			n, err := writer.Write([]byte("123456789"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(9))
+
+			// when
+			n, err = writer.Write([]byte("123456789"))
+
+			// then
+			Expect(err).To(HaveOccurred())
+			Expect(n).To(Equal(0))
+		})
+	})
+
+	Context("Start/stop operations", func() {
+		It("Cannot retrieve logs", func() {
+			// given
+			writer := logs.NewWorkloadWriter("workload", wkManager)
+			writer.SetTarget("test", target)
+			// then
+
+			wkwMock.EXPECT().Logs("workload", gomock.Any()).Times(1).Return(nil, errors.New("failed"))
+
+			// when
+			err := writer.Start()
+			Expect(err).To(HaveOccurred())
+
+			// just to make sure that it's working as expected
+			writer.Stop()
+		})
+
+		It("Retrieve logs correctly", func() {
+			// given
+			writer := logs.NewWorkloadWriter("workload", wkManager)
+			writer.SetTarget("test", target)
+			// then
+
+			wkwMock.EXPECT().Logs("workload", gomock.Any()).Times(1)
+
+			// when
+			err := writer.Start()
+			Expect(err).NotTo(HaveOccurred())
+
+			// just to make sure that it's working as expected
+			writer.Stop()
+		})
+
+	})
+})

--- a/internal/workload/manager.go
+++ b/internal/workload/manager.go
@@ -2,7 +2,9 @@ package workload
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -211,6 +213,10 @@ func (w *WorkloadManager) Update(configuration models.DeviceConfigurationMessage
 	}
 
 	return errors
+}
+
+func (w *WorkloadManager) Logs(podID string, res io.Writer) (context.CancelFunc, error) {
+	return w.workloads.Logs(podID, res)
 }
 
 func (w *WorkloadManager) ensureWorkloadDirExists(workloadName string) error {

--- a/internal/workload/mock_wrapper.go
+++ b/internal/workload/mock_wrapper.go
@@ -5,6 +5,8 @@
 package workload
 
 import (
+	context "context"
+	io "io"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -91,6 +93,21 @@ func (m *MockWorkloadWrapper) ListSecrets() (map[string]struct{}, error) {
 func (mr *MockWorkloadWrapperMockRecorder) ListSecrets() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockWorkloadWrapper)(nil).ListSecrets))
+}
+
+// Logs mocks base method.
+func (m *MockWorkloadWrapper) Logs(arg0 string, arg1 io.Writer) (context.CancelFunc, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Logs", arg0, arg1)
+	ret0, _ := ret[0].(context.CancelFunc)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Logs indicates an expected call of Logs.
+func (mr *MockWorkloadWrapperMockRecorder) Logs(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logs", reflect.TypeOf((*MockWorkloadWrapper)(nil).Logs), arg0, arg1)
 }
 
 // PersistConfiguration mocks base method.

--- a/internal/workload/wrapper.go
+++ b/internal/workload/wrapper.go
@@ -1,7 +1,10 @@
 package workload
 
 import (
+	"context"
 	"fmt"
+
+	"io"
 	"sync"
 
 	"github.com/project-flotta/flotta-device-worker/internal/service"
@@ -29,6 +32,7 @@ type WorkloadWrapper interface {
 	Init() error
 	RegisterObserver(Observer)
 	List() ([]api.WorkloadInfo, error)
+	Logs(podID string, res io.Writer) (context.CancelFunc, error)
 	Remove(string) error
 	Stop(string) error
 	Run(*v1.Pod, string, string) error
@@ -141,6 +145,10 @@ func (ww *Workload) List() ([]api2.WorkloadInfo, error) {
 		}
 	}
 	return infos, err
+}
+
+func (ww *Workload) Logs(podID string, res io.Writer) (context.CancelFunc, error) {
+	return ww.workloads.Logs(podID, res)
 }
 
 func (ww *Workload) Remove(workloadName string) error {


### PR DESCRIPTION
This PR adds a way to send logs to a Syslog server, or any other platform that implements the interface in the future.

The main goal is to read Pod logs and store them on an intermediate struct (Fifolog) that buffers (With limits defined by a user) and sends it to the given server with retries, etc.. 

Users can define multiple Syslog servers at the device level, like: 

```
apiVersion: management.project-flotta.io/v1alpha1
kind: EdgeDevice
metadata:
  name: XXXX
  namespace: default
spec:
  log_collection:
    syslog:
      BufferSize: 10
      kind: syslog
      syslogConfig:
        address: dc1-log.acme.org:601
        proto: tcp
    importantLogs:
      BufferSize: 1000
      kind: syslog
      syslogConfig:
        address: custom-syslog.acme.org:601
        proto: tcp
``` 

And assign log transport on the deploy side using this format: 

```
---
apiVersion: management.project-flotta.io/v1alpha1
kind: EdgeDeployment
metadata:
  name: random-deployment
spec:
  deviceSelector:
    matchLabels:
      app: foo
  type: pod
  log_collection: importantLogs
  pod:
    spec:
      containers:
        - name: random-server
          image: eloycoto/test
          ports:
            - containerPort: 8080
              hostPort: 9099
```

Fix: https://issues.redhat.com/browse/ECOPROJECT-423
RFC-DOC: https://docs.google.com/document/d/1_hWAmLxZWkivIPe_XcoR6xxomuHFTqw4aB_A30MYOUc/edit
Depends-on: https://github.com/project-flotta/flotta-operator/pull/113