### PR TITLE
Tolerate missing OS configuration

### DIFF
--- a/internal/os/os.go
+++ b/internal/os/os.go
@@ -103,13 +103,14 @@ func (o *OS) Init(config models.DeviceConfigurationMessage) error {
 }
 
 func (o *OS) Update(configuration models.DeviceConfigurationMessage) error {
+	newOSInfo := configuration.Configuration.Os
+	if newOSInfo == nil {
+		log.Debug("No OS management configuration. Not updating.")
+		return nil
+	}
 	if !o.Enabled {
 		log.Debug("OS management is not available. Not updating OS configuration")
 		return nil
-	}
-	newOSInfo := configuration.Configuration.Os
-	if newOSInfo == nil {
-		return fmt.Errorf("cannot retrieve configuration info.")
 	}
 
 	if newOSInfo.HostedObjectsURL != o.HostedObjectsURL {

--- a/internal/os/os_test.go
+++ b/internal/os/os_test.go
@@ -155,6 +155,19 @@ var _ = Describe("Os", func() {
 
 	Context("Run Update OS test", func() {
 
+		It("No OS configuration", func() {
+			// given
+			cfg := models.DeviceConfigurationMessage{
+				Configuration: &models.DeviceConfiguration{},
+			}
+
+			// when
+			err := deviceOS.Update(cfg)
+
+			//then
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		It("Changing the HostedURL", func() {
 			// given
 			cfg := createConfig(true, OldCommitID, NewHostedUrl)


### PR DESCRIPTION
This PR resolves problem described in https://issues.redhat.com/browse/ECOPROJECT-587. And allows for OS configuration to be missing (which is the case before the device is registered).