### PR TITLE
RPM: Build flotta-agent-race package

### DIFF
--- a/flotta-agent.spec
+++ b/flotta-agent.spec
@@ -18,6 +18,13 @@ Requires:       yggdrasil
 Provides:       %{name} = %{version}-%{release}
 Provides:       golang(%{go_import_path}) = %{version}-%{release}
 
+%package        race
+Summary:        flotta-agent with race-enabled
+
+%description race
+The same as flotta agent, but in this case compiled with --race flag to be able
+to detect race-conditions in the e2e test
+
 %description
 The Flotta agent communicates with the Flotta control plane. It reports the status of the appliance and of the running PODs/containers. Agent is responsible for starting and stopping PODs that are based on commands from the control plane.
 
@@ -25,24 +32,33 @@ The Flotta agent communicates with the Flotta control plane. It reports the stat
 systemctl enable --now podman.socket
 systemctl enable --now nftables.service
 
-%prep 
+%prep
 tar fx %{SOURCE0}
 
 %build
 cd flotta-agent-%{VERSION}
-export CGO_ENABLED=0 
+export CGO_ENABLED=0
 export GOFLAGS="-mod=vendor -tags=containers_image_openpgp"
 go build -o ./bin/device-worker ./cmd/device-worker
+go build -o ./bin/device-worker-race ./cmd/device-worker
 
 %install
 cd flotta-agent-%{VERSION}
 mkdir -p %{buildroot}%{_libexecdir}/yggdrasil/
 install ./bin/device-worker %{buildroot}%{_libexecdir}/yggdrasil/device-worker
+install ./bin/device-worker-race %{buildroot}%{_libexecdir}/yggdrasil/device-worker-race
 make install-worker-config LIBEXECDIR=%{_libexecdir} BUILDROOT=%{buildroot} SYSCONFDIR=%{_sysconfdir}
 
 %files
 %{_libexecdir}/yggdrasil/device-worker
 %{_sysconfdir}/yggdrasil/
+
+%files race
+%{_libexecdir}/yggdrasil/device-worker-race
+%{_sysconfdir}/yggdrasil/
+
+%post race
+ln -sf %{_libexecdir}/yggdrasil/device-worker-race %{_libexecdir}/yggdrasil/device-worker
 
 %changelog
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,7 +7,7 @@ RUN dnf copr enable project-flotta/flotta -y
 # Yum dependencies
 RUN dnf update -y \
   && dnf install -y openssl procps-ng dmidecode nc \
-  yggdrasil flotta-agent node_exporter
+  yggdrasil flotta-agent-race node_exporter
 
 # Modify podman configuration
 RUN sed -i s/netns=\"host\"/netns=\"private\"/g /etc/containers/containers.conf && \


### PR DESCRIPTION
To be able to test with race conditions enabled and be able to debug
that there is no race-conditions in the integration test at all.

Related-to: https://issues.redhat.com/browse/ECOPROJECT-473

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>