### PR TITLE
Avoid duplicate configuration updates at the cost of increased contention

### DIFF
--- a/internal/server/deviceserver.go
+++ b/internal/server/deviceserver.go
@@ -3,8 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"sync"
-
 	"git.sr.ht/~spc/go-log"
 	configuration2 "github.com/project-flotta/flotta-device-worker/internal/configuration"
 	registration2 "github.com/project-flotta/flotta-device-worker/internal/registration"
@@ -14,48 +12,53 @@ import (
 
 type deviceServer struct {
 	pb.UnimplementedWorkerServer
-	configManager       *configuration2.Manager
-	registrationManager *registration2.Registration
-	updateLock       sync.Mutex
+	deviceID             string
+	registrationManager  *registration2.Registration
+	configurationUpdates chan models.DeviceConfigurationMessage
 }
 
 func NewDeviceServer(configManager *configuration2.Manager, registrationManager *registration2.Registration) *deviceServer {
-	return &deviceServer{
-		configManager:       configManager,
-		registrationManager: registrationManager,
+	server := &deviceServer{
+		deviceID:             configManager.GetDeviceID(),
+		registrationManager:  registrationManager,
+		configurationUpdates: make(chan models.DeviceConfigurationMessage),
 	}
+
+	go func() {
+		for deviceConfigurationMessage := range server.configurationUpdates {
+			err := configManager.Update(deviceConfigurationMessage)
+			if err != nil {
+				log.Warnf("failed to process message. DeviceID: %s; err: %v", server.deviceID, err)
+			}
+		}
+	}()
+	return server
 }
 
 // Send implements the "Send" method of the Worker gRPC service.
-func (s *deviceServer) Send(ctx context.Context, d *pb.Data) (*pb.Receipt, error) {
+func (s *deviceServer) Send(_ context.Context, d *pb.Data) (*pb.Receipt, error) {
 	go func() {
 		deviceConfigurationMessage := models.DeviceConfigurationMessage{}
 		err := json.Unmarshal(d.Content, &deviceConfigurationMessage)
 		if err != nil {
-			log.Warnf("cannot unmarshal message. DeviceID: %s; err: %v", s.configManager.GetDeviceID(), err)
+			log.Warnf("cannot unmarshal message. DeviceID: %s; err: %v", s.deviceID, err)
 		}
-		// Don't allow for parallel configuration updates if one of them takes longer.
-		s.updateLock.Lock()
-		defer s.updateLock.Unlock()
-		err = s.configManager.Update(deviceConfigurationMessage)
-		if err != nil {
-			log.Warnf("failed to process message. DeviceID: %s; err: %v", s.configManager.GetDeviceID(), err)
-		}
+		s.configurationUpdates <- deviceConfigurationMessage
 	}()
 
 	// Respond to the start request that the work was accepted.
 	return &pb.Receipt{}, nil
 }
 
-// Disconnect implements the "Disconnect" method of the Worker gRPC service.
+// NotifyEvent implements the "NotifyEvent" method of the Worker gRPC service.
 func (s *deviceServer) NotifyEvent(ctx context.Context, in *pb.EventNotification) (*pb.EventReceipt, error) {
-	log.Infof("received worker event. DeviceID: %s; Event: %s", s.configManager.GetDeviceID(), in.Name)
+	log.Infof("received worker event. DeviceID: %s; Event: %s", s.deviceID, in.Name)
 
 	if in.Name == pb.Event_RECEIVED_DISCONNECT {
-		log.Infof("Starting unregisting DeviceID: %s", s.configManager.GetDeviceID())
+		log.Infof("Starting unregisting DeviceID: %s", s.deviceID)
 		err := s.registrationManager.Deregister()
 		if err != nil {
-			log.Warnf("cannot disconnect. DeviceID: %s; err: %v", s.configManager.GetDeviceID(), err)
+			log.Warnf("cannot disconnect. DeviceID: %s; err: %v", s.deviceID, err)
 		}
 	}
 	return &pb.EventReceipt{}, nil


### PR DESCRIPTION
This PR adds locking on handling of configuration messages to avoid unnecessary duplicate configuration updates.
Issue has been described in https://issues.redhat.com/browse/ECOPROJECT-284