### PR TITLE
Update `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ DOCKER ?= podman
 IMG ?= quay.io/project-flotta/edgedevice:latest
 
 ifeq ($(OS),fedora)
-	LIBEXECDIR ?= /usr/local/libexec
-	SYSCONFDIR ?= /usr/local/etc
+	LIBEXECDIR ?= /var/local/libexec
+	SYSCONFDIR ?= /var/local/etc
 else
-	LIBEXECDIR ?= /usr/libexec
+	LIBEXECDIR ?= /var/libexec
 	SYSCONFDIR ?= /etc
 endif
 
@@ -97,17 +97,22 @@ install-worker-config:
 	sed 's,#LIBEXEC#,$(LIBEXECDIR),g' config/device-worker.toml > $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/workers/device-worker.toml
 
 install: ## Install device-worker with debug enabled
-install-debug: build-debug install-worker-config
+install-debug: build-debug
+	sudo $(MAKE) install-worker-config
 	sudo install -D -m 755 ./bin/device-worker $(LIBEXECDIR)/yggdrasil/device-worker
 
 install: ## Install device-worker
-install: build install-worker-config
+install: build
+	sudo $(MAKE) install-worker-config
 	sudo install -D -m 755 ./bin/device-worker $(LIBEXECDIR)/yggdrasil/device-worker
 
 install-arm64: ## Install device-worker on arm64.
-install-arm64: build-arm64 install-worker-config
+install-arm64: build-arm64
+	sudo $(MAKE) install-worker-config
 	sudo install -D -m 755 ./bin/device-worker-aarch64 $(LIBEXECDIR)/yggdrasil/device-worker
 
+uninstall: clean
+	sudo rm -rf $(SYSCONFDIR)/yggdrasil/device/*
 
 rpm-tarball:
 	 (git archive --prefix flotta-agent-$(VERSION)/ HEAD ) \

--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ make rpm
 To start the device-worker in clean (pairing) mode, make sure that following files are not present before starting
 yggdrasil:
 
-- `/var/local/yggdrasil/device/device-config.json`
+- `/var/local/etc/yggdrasil/device/device-config.json`
 - `/var/local/yggdrasil/device/manifests/*`
+
+Or run:
+`make uninstall`
 
 # Running
 
@@ -49,12 +52,13 @@ To install Yggdrasil from upstream repo:
 git clone git@github.com:RedHatInsights/yggdrasil.git
 cd yggdrasil
 git checkout d696ee7a54bbf5775a88447bc40aae2259e8144c
-make
+export PREFIX=/var/local
+make bin
 ```
 
-
+Start yggdrasil:
 ```
-sudo go run ./cmd/yggd \
+sudo ./yggd \
   --log-level info \
   --protocol http \
   --path-prefix api/flotta-management/v1 \
@@ -67,7 +71,7 @@ sudo go run ./cmd/yggd \
 Also, the worker config need to be defined in the right location:
 
 ```
---> cat /usr/local/etc/yggdrasil/workers/device-worker.toml
+$ cat /var/local/etc/yggdrasil/workers/device-worker.toml
 exec = "/usr/local/libexec/yggdrasil/device-worker"
 protocol = "grpc"
 env = []


### PR DESCRIPTION
Removed the requirement for root permissions in `make install`.
Added `make uninstall`.
Replaced the path of `LIBEXECDIR` and `SYSCONFDIR` to be under `/var` instead of `/usr`.
Added documentation regarding all the above to the `README`.

Signed-off-by: arielireni <aireni@redhat.com>