### PR TITLE
Test: Fix target url for yggdrasil

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir /etc/pki/consumer && \
 RUN echo "" > /etc/yggdrasil/config.toml && \
     echo 'key-file = "/etc/pki/consumer/key.pem"' >> /etc/yggdrasil/config.toml && \
     echo 'cert-file = "/etc/pki/consumer/cert.pem"' >> /etc/yggdrasil/config.toml && \
-    echo 'server = "172.17.0.1:8888"' >> /etc/yggdrasil/config.toml && \
+    echo 'server = "project-flotta.io:8043"' >> /etc/yggdrasil/config.toml && \
     echo 'protocol = "http"' >> /etc/yggdrasil/config.toml && \
     echo 'path-prefix="api/flotta-management/v1"' >> /etc/yggdrasil/config.toml && \
     echo 'log-level="trace"' >> /etc/yggdrasil/config.toml


### PR DESCRIPTION
Using the right target url for testing, in this case project-flotta.io,
to mach the domain.A followup PR on operator to add the hostname on
container run.

Fix: https://issues.redhat.com/browse/ECOPROJECT-399

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>