### PR TITLE
Fix: AfterEach in configuration_test doesn't delete datadir

### DIFF
--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -69,7 +69,12 @@ var _ = Describe("Configuration", func() {
 
 	AfterEach(func() {
 		mockCtrl.Finish()
-		_ = os.Remove(datadir)
+
+		err = os.Chmod(datadir, 0750)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.RemoveAll(datadir)
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Context("NewConfigurationManager", func() {


### PR DESCRIPTION
AfterEach function doesn't check the os.Remove error.
In addition the os.Remove fails always because the directory is never
empty.

Replace os.Remove with os.RemoveAll fixes the problem.
To be sure to have the permission to delete the folder, this PR also
invokes os.Chmod function.

Signed-off-by: Gloria Ciavarrini <gciavarrini@redhat.com>