### PR TITLE
Dockerfile: pull nginx image for speed the testing

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -6,12 +6,14 @@ RUN dnf copr enable project-flotta/flotta -y
 
 # Yum dependencies
 RUN dnf update -y \
-  && dnf install -y openssl procps-ng dmidecode nc \
+  && dnf install -y openssl procps-ng dmidecode nc iproute \
   yggdrasil flotta-agent-race node_exporter
 
 # Modify podman configuration
 RUN sed -i s/netns=\"host\"/netns=\"private\"/g /etc/containers/containers.conf && \
     sed -i s/utsns=\"host\"/utsns=\"private\"/g /etc/containers/containers.conf
+
+RUN podman pull quay.io/bitnami/nginx:1.21.6
 
 # Certificate reqs:
 RUN mkdir /etc/pki/consumer && \


### PR DESCRIPTION
When testing integration, if quay is down or slow can affect our e2e
test, so in this case, I added the image in there, so no download issue
can affect the CI.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>