### PR TITLE
enable TLS for metrics remote writer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/opencontainers/runtime-tools v0.9.1-0.20211020193359-09d837bf40a7 // indirect
 	github.com/openshift/assisted-installer-agent v1.0.10-0.20211027185717-53b0eacfa147
 	github.com/pkg/errors v0.9.1
-	github.com/project-flotta/flotta-operator v0.0.2-0.20220404113302-b5aed0516daa
+	github.com/project-flotta/flotta-operator v0.0.2-0.20220410092926-9776a65d2c69
 	github.com/prometheus/common v0.32.1
 	github.com/prometheus/prometheus v1.8.2-0.20211217191541-41f1a8125e66
 	github.com/redhatinsights/yggdrasil v0.0.0-20220309180936-d91759a7f332

--- a/go.sum
+++ b/go.sum
@@ -1613,6 +1613,8 @@ github.com/pquerna/ffjson v0.0.0-20181028064349-e517b90714f7/go.mod h1:YARuvh7BU
 github.com/pquerna/ffjson v0.0.0-20190813045741-dac163c6c0a9/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
 github.com/project-flotta/flotta-operator v0.0.2-0.20220404113302-b5aed0516daa h1:S0/GJrH27T7gnw0jwqiKb38B2uaqEDsr09WOwl7UXQg=
 github.com/project-flotta/flotta-operator v0.0.2-0.20220404113302-b5aed0516daa/go.mod h1:b5GaqFr2lTYTfM3+L3v5p0NsMahZNk1AmUjM6kq+p2w=
+github.com/project-flotta/flotta-operator v0.0.2-0.20220410092926-9776a65d2c69 h1:5JouD+fp7GpiAm8ywfuyX9HFFMUDlDpRGP6RIhPniYs=
+github.com/project-flotta/flotta-operator v0.0.2-0.20220410092926-9776a65d2c69/go.mod h1:b5GaqFr2lTYTfM3+L3v5p0NsMahZNk1AmUjM6kq+p2w=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.49.0/go.mod h1:3WYi4xqXxGGXWDdQIITnLNmuDzO5n6wYva9spVhR4fg=
 github.com/prometheus/alertmanager v0.20.0/go.mod h1:9g2i48FAyZW6BtbsnvHtMHQXl2aVtrORKwKVCQ+nbrg=
 github.com/prometheus/alertmanager v0.23.0/go.mod h1:0MLTrjQI8EuVmvykEhcfr/7X0xmaDAZrqMgxIq3OXHk=
@@ -1934,6 +1936,12 @@ github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6Ut
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/ydayagi/k4e-operator v0.0.0-20220329090830-d066b756c24a h1:ptGSwDSKP5JHpnymn0mmdLfEdHGGyXWUiZzTfAy89zI=
+github.com/ydayagi/k4e-operator v0.0.0-20220329090830-d066b756c24a/go.mod h1:YsPyFYCu5fxTfh/9kenH40UgxqAtfOZNt1hnZH2royA=
+github.com/ydayagi/k4e-operator v0.0.0-20220404220543-73cfaaad2382 h1:UT/XY1xxeR36kmRUjhP8coIn8mFkKC7ZoBd3a4FSEbA=
+github.com/ydayagi/k4e-operator v0.0.0-20220404220543-73cfaaad2382/go.mod h1:b5GaqFr2lTYTfM3+L3v5p0NsMahZNk1AmUjM6kq+p2w=
+github.com/ydayagi/k4e-operator v0.0.0-20220410072327-e13e62fc2c96 h1:b2J4remQORnqPQS5vdIxBwRQT7pIaOBXRIlemON0164=
+github.com/ydayagi/k4e-operator v0.0.0-20220410072327-e13e62fc2c96/go.mod h1:b5GaqFr2lTYTfM3+L3v5p0NsMahZNk1AmUjM6kq+p2w=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/metrics/remote_write_test.go
+++ b/internal/metrics/remote_write_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"path"
 	"time"
 
 	gomock "github.com/golang/mock/gomock"
@@ -25,22 +26,71 @@ var _ = Describe("remote write", func() {
 
 	Context("observer", func() {
 		var (
+			tmpDir       = ""
 			tsdbInstance metrics.API
+			caStr        = `-----BEGIN CERTIFICATE-----
+MIIFiDCCA3CgAwIBAgIUWlVM1UdWMTANbe+XsXplZsvVrHQwDQYJKoZIhvcNAQEL
+BQAwSTELMAkGA1UEBhMCRVUxCzAJBgNVBAgMAk5vMQ4wDAYDVQQHDAVTdGF0ZTEK
+MAgGA1UECgwBRDERMA8GA1UEAwwIcmVjZWl2ZXIwHhcNMjIwNDA0MDgzMjUxWhcN
+MzIwNDAxMDgzMjUxWjBJMQswCQYDVQQGEwJFVTELMAkGA1UECAwCTm8xDjAMBgNV
+BAcMBVN0YXRlMQowCAYDVQQKDAFEMREwDwYDVQQDDAhyZWNlaXZlcjCCAiIwDQYJ
+KoZIhvcNAQEBBQADggIPADCCAgoCggIBALyt9dKvRF2BP5nRjcDzDL7erP0X1dzp
+gzqX5j0O+CsrI8Iw/BngWF4BQ8LBgHkI8vzXv3H80BCPTDo7D+GEkQBM3oYINp+v
+VjOJ2WsY9KJ5tG/Qdk40QHK8PluCIIvfZd1ZuCksNQaeSoBBhO2uDimjRuQr2j4j
+rA7+tDl5ijo+Owk6cXxZSa6YV5LhMV55+U7hQq6BIMxFsfuyOcfeG0fqiMdlrlnC
+riEm0EPGkGjOW8tdXgtNpg3DhOFNcMtk+sgGL8BNydRUVJh6g7lvmgll/HL6usAU
+pjb0i+B7bNoHznFhw71G4QtaHO/bGnRer7eOv7/JyEg456ILhy3SOvDRMxueKN3g
+6qyN2lb405AfElEzr9NBTQQihhItVaDFa2JfP02g59MqsTC+BgNyKk25lPzPrAHo
+6Lgp9m7nmWWvj/8kze3VLNVhqmAM8Bhh+50PEmpYOP5K/w1PLdI/VRVCXxinu/Z4
+XzxU3do5g8kjMqQJwkHXXV5zsLsBYHJP5/P2cvuGlYbWx8pLdMti36lGx8qtHhXS
+x/41SIySjc6YxEOt3DSGG0ZcU3Fn+KRnZm8Pl1lQwuioSzOimKlAkn1yIjKgqdMI
+beOuiu6D00inYB3ZEEuQVXtCiCHQNligR/k2Qej2cdsedazFDGVjjSBjWhGKDmXo
+4p3AoiJSHv6XAgMBAAGjaDBmMB0GA1UdDgQWBBQsOQ3FVc7Ko6fpN/UuVwTTcsX2
+BTAfBgNVHSMEGDAWgBQsOQ3FVc7Ko6fpN/UuVwTTcsX2BTAPBgNVHRMBAf8EBTAD
+AQH/MBMGA1UdEQQMMAqCCHJlY2VpdmVyMA0GCSqGSIb3DQEBCwUAA4ICAQCIweEe
+KROsR1jLJFT3s+hQzI0TCCdKsbCHRhMAFttRhmE42gTyzqggJdpwuNA0wfDLyQcg
+KGHCqG22KtyoBUoTiHuQxh7gkMv6rxCHgEbwKjF2XCUm3KZ1lH5I7LtK5VzzCRFu
+xgGA2mvK7nG4KMIUOChSJiBLAti6MP5Azw861qAXSARSd2721sdUzAScrZa0KpBj
+WVqpxg9Hlb4Ad4tApoj1q8MTOdClESSTJJSynQ796Amg3Indgj2qDyQ70SaJd8s9
+tNujtWro+66Wlt2jE2S8S1yL2tRb1tNp43Yqg8IlqGUU/fLVjiNI6KQ+onGhOkOt
+nTboLb4xa2C6dgNYi80NTnZ3mETnkYC/sLaA3yv2HB9zfG+MhT69H8zRsSDmzHRX
+oPWv326JhQwtrBgwXifd8OI43LPIeGNxM+ElyNJZOeQVySb9TMpqk9gTsfLDb7fT
+8h2vlPnQMNiUfn1B4hJ0Sm5CMlZ28ig1MF1YDy1DUWlnzeGOcBgz4c1l0J1wwHto
+XEC7dPo8bMY7D8RCD7e9uKm9MbFntQSt+yDR2RftyxNfoPv42C6d35f4xNOJJv0E
+9p16bl/jBfi66oVfZqypLMu7Xm4ChJz/pEY4HmiMVZ0Xo/BIlUG4NDxve2qU0CA9
+W5WPOpTBuB5eJ1Clr/7QePRsMcRMOCTRloMTQg==
+-----END CERTIFICATE-----`
 		)
 
+		listCaFiles := func() (result []string) {
+			files, err := ioutil.ReadDir(tmpDir)
+			Expect(err).To(BeNil())
+			for _, file := range files {
+				match, err := path.Match(metrics.ServerCAFileNamePattern, file.Name())
+				Expect(err).To(BeNil())
+				if match {
+					result = append(result, file.Name())
+				}
+			}
+			return
+		}
+
 		BeforeEach(func() {
-			tmpDir, err := ioutil.TempDir("", "metrics")
+			var err error
+			tmpDir, err = ioutil.TempDir("", "metrics")
 			Expect(err).ToNot(HaveOccurred())
 
 			tsdbInstance, err = metrics.NewTSDB(tmpDir)
 			Expect(err).NotTo(HaveOccurred())
 
-			remoteWrite = metrics.NewRemoteWrite("", deviceID, tsdbInstance)
+			remoteWrite = metrics.NewRemoteWrite(tmpDir, deviceID, tsdbInstance)
 		})
 
 		AfterEach(func() {
 			err := tsdbInstance.Deregister()
 			Expect(err).ToNot(HaveOccurred())
+			Expect(tmpDir).NotTo(BeEmpty())
+			os.RemoveAll(tmpDir)
 		})
 
 		It("Init with feature disabled", func() {
@@ -67,6 +117,7 @@ var _ = Describe("remote write", func() {
 							RequestNumSamples: int64(requestNumSamples),
 							TimeoutSeconds:    10,
 							URL:               "http://something",
+							CaCert:            caStr,
 						},
 					},
 				},
@@ -79,6 +130,7 @@ var _ = Describe("remote write", func() {
 			Expect(err).To(BeNil())
 			Expect(remoteWrite.IsEnabled()).To(BeTrue())
 			Expect(remoteWrite.IsRunning()).To(BeTrue())
+			Expect(listCaFiles()).To(HaveLen(1))
 		})
 
 		It("Update", func() {
@@ -90,6 +142,7 @@ var _ = Describe("remote write", func() {
 							RequestNumSamples: int64(requestNumSamples),
 							TimeoutSeconds:    10,
 							URL:               "http://something",
+							CaCert:            caStr,
 						},
 					},
 				},
@@ -118,6 +171,7 @@ var _ = Describe("remote write", func() {
 			Expect(remoteWrite.IsEnabled()).To(BeTrue())
 			Expect(remoteWrite.IsRunning()).To(BeTrue())
 			Expect(remoteWrite.Config).To(Equal(configMessage2.Configuration.Metrics.Receiver))
+			Expect(listCaFiles()).To(HaveLen(0))
 		})
 
 		It("Update - enable feature", func() {
@@ -136,6 +190,7 @@ var _ = Describe("remote write", func() {
 							RequestNumSamples: int64(requestNumSamples),
 							TimeoutSeconds:    10,
 							URL:               "http://something",
+							CaCert:            caStr,
 						},
 					},
 				},
@@ -148,6 +203,7 @@ var _ = Describe("remote write", func() {
 			Expect(err).To(BeNil())
 			Expect(remoteWrite.IsEnabled()).To(BeTrue())
 			Expect(remoteWrite.IsRunning()).To(BeTrue())
+			Expect(listCaFiles()).To(HaveLen(1))
 		})
 
 		It("Update - disable feature", func() {
@@ -160,6 +216,7 @@ var _ = Describe("remote write", func() {
 							RequestNumSamples: int64(requestNumSamples),
 							TimeoutSeconds:    10,
 							URL:               "http://something",
+							CaCert:            caStr,
 						},
 					},
 				},
@@ -188,6 +245,7 @@ var _ = Describe("remote write", func() {
 			Expect(err).To(BeNil())
 			Expect(remoteWrite.IsEnabled()).To(BeFalse())
 			Eventually(remoteWrite.IsRunning, "50ms").Should(BeFalse())
+			Expect(listCaFiles()).To(HaveLen(0))
 		})
 	})
 

--- a/vendor/github.com/project-flotta/flotta-operator/models/metrics_receiver_configuration.go
+++ b/vendor/github.com/project-flotta/flotta-operator/models/metrics_receiver_configuration.go
@@ -15,6 +15,9 @@ import (
 // swagger:model metrics-receiver-configuration
 type MetricsReceiverConfiguration struct {
 
+	// ca cert
+	CaCert string `json:"caCert,omitempty"`
+
 	// request num samples
 	RequestNumSamples int64 `json:"request_num_samples,omitempty"`
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -647,7 +647,7 @@ github.com/ostreedev/ostree-go/pkg/otbuiltin
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/project-flotta/flotta-operator v0.0.2-0.20220404113302-b5aed0516daa
+# github.com/project-flotta/flotta-operator v0.0.2-0.20220410092926-9776a65d2c69
 ## explicit
 github.com/project-flotta/flotta-operator/models
 github.com/project-flotta/flotta-operator/pkg/mtls


### PR DESCRIPTION
Pass an optional CA to the device
This is the CA that signs the metrics receiver's certificate

https://issues.redhat.com/browse/ECOPROJECT-579
enable TLS in device remote write

Signed-off-by: Yaron Dayagi <ydayagi@redhat.com>