### PR TITLE
Use custom systemd service configuration for autoupdate

### DIFF
--- a/internal/workload/podman/mock_podman.go
+++ b/internal/workload/podman/mock_podman.go
@@ -12,6 +12,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	service "github.com/project-flotta/flotta-device-worker/internal/service"
 	api "github.com/project-flotta/flotta-device-worker/internal/workload/api"
+	v1 "k8s.io/api/core/v1"
 )
 
 // MockPodman is a mock of Podman interface.
@@ -67,18 +68,18 @@ func (mr *MockPodmanMockRecorder) Exists(arg0 interface{}) *gomock.Call {
 }
 
 // GenerateSystemdService mocks base method.
-func (m *MockPodman) GenerateSystemdService(arg0 string, arg1 uint) (service.Service, error) {
+func (m *MockPodman) GenerateSystemdService(arg0 *v1.Pod, arg1 string, arg2 uint) (service.Service, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateSystemdService", arg0, arg1)
+	ret := m.ctrl.Call(m, "GenerateSystemdService", arg0, arg1, arg2)
 	ret0, _ := ret[0].(service.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateSystemdService indicates an expected call of GenerateSystemdService.
-func (mr *MockPodmanMockRecorder) GenerateSystemdService(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPodmanMockRecorder) GenerateSystemdService(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateSystemdService", reflect.TypeOf((*MockPodman)(nil).GenerateSystemdService), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateSystemdService", reflect.TypeOf((*MockPodman)(nil).GenerateSystemdService), arg0, arg1, arg2)
 }
 
 // List mocks base method.

--- a/internal/workload/wrapper.go
+++ b/internal/workload/wrapper.go
@@ -237,7 +237,7 @@ func (ww *Workload) Run(workload *v1.Pod, manifestPath string, authFilePath stri
 	}
 
 	// Create the system service to manage the pod:
-	svc, err := ww.workloads.GenerateSystemdService(workload.Name, ww.monitoringInterval)
+	svc, err := ww.workloads.GenerateSystemdService(workload, manifestPath, ww.monitoringInterval)
 	if err != nil {
 		return fmt.Errorf("Error while generating systemd service: %v", err)
 	}

--- a/internal/workload/wrapper_test.go
+++ b/internal/workload/wrapper_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Workload management", func() {
 			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}
 
 			newPodman.EXPECT().Run(manifestPath, authFilePath).Return([]*podman.PodReport{{Id: "id1"}}, nil)
-			newPodman.EXPECT().GenerateSystemdService(gomock.Any(), gomock.Any()).Return(svc, nil)
+			newPodman.EXPECT().GenerateSystemdService(pod, gomock.Any(), gomock.Any()).Return(svc, nil)
 
 			svc.EXPECT().Add().Return(nil)
 			svc.EXPECT().Enable().Return(nil)
@@ -80,7 +80,7 @@ var _ = Describe("Workload management", func() {
 			mappingRepository.EXPECT().Add("pod1", "id1")
 
 			newPodman.EXPECT().Run(manifestPath, authFilePath).Return([]*podman.PodReport{{Id: "id1"}}, nil)
-			newPodman.EXPECT().GenerateSystemdService(gomock.Any(), gomock.Any()).Return(svc, nil)
+			newPodman.EXPECT().GenerateSystemdService(pod, gomock.Any(), gomock.Any()).Return(svc, nil)
 
 			svc.EXPECT().Add().Return(fmt.Errorf("Failed to add service"))
 
@@ -99,7 +99,7 @@ var _ = Describe("Workload management", func() {
 			mappingRepository.EXPECT().Add("pod1", "id1")
 
 			newPodman.EXPECT().Run(manifestPath, authFilePath).Return([]*podman.PodReport{{Id: "id1"}}, nil)
-			newPodman.EXPECT().GenerateSystemdService(gomock.Any(), gomock.Any()).Return(svc, nil)
+			newPodman.EXPECT().GenerateSystemdService(pod, gomock.Any(), gomock.Any()).Return(svc, nil)
 
 			svc.EXPECT().Add().Return(nil)
 			svc.EXPECT().Enable().Return(nil)


### PR DESCRIPTION
This commit add special systemd service configuration for the pods which
are configured to use autoupdate podman feature. The reason for this is
that podman `generate systemd` command doesnt' support generation of the
services for pod, which were created via API, or via podman play kube.
Default service generation only restarts the pod, while this custom
configuration re-create the container so the newer image could be used.

Signed-off-by: Ondra Machacek <omachace@redhat.com>