### PR TITLE
Registration: no need to call config

### DIFF
--- a/internal/registration/registration.go
+++ b/internal/registration/registration.go
@@ -138,15 +138,13 @@ func (r *Registration) RegisterDevice() {
 func (r *Registration) registerDeviceWithRetries(interval int64) {
 	ticker := time.NewTicker(time.Second * time.Duration(interval))
 	for range ticker.C {
-		if !r.config.IsInitialConfig() {
-			ticker.Stop()
-			break
-		}
 		log.Infof("configuration has not been initialized yet. Sending registration request. DeviceID: %s;", r.deviceID)
 		err := r.registerDeviceOnce()
 		if err != nil {
 			log.Errorf("cannot register device. DeviceID: %s; err: %v", r.deviceID, err)
+			continue
 		}
+		ticker.Stop()
 	}
 }
 


### PR DESCRIPTION
When re-register there is no need to call the config instance, due there
is async process by the yggdrasil heartbeat, and it has a race condition
on the approval process.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>