### PR TITLE
Remove pulling of podman nginx image

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -13,11 +13,7 @@ RUN dnf update -y \
 RUN sed -i s/netns=\"host\"/netns=\"private\"/g /etc/containers/containers.conf && \
     sed -i s/utsns=\"host\"/utsns=\"private\"/g /etc/containers/containers.conf
 
-USER flotta
-RUN podman pull quay.io/bitnami/nginx:1.21.6
-
 # Certificate reqs:
-USER root
 RUN mkdir /etc/pki/consumer && \
     openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -out cert.pem -keyout key.pem -subj "/C=EU/ST=No/L=State/O=D/CN=www.example.com" && \
     mv cert.pem key.pem /etc/pki/consumer


### PR DESCRIPTION
This patch remove the pulling of the nginx image.

It doesn't work in the CI for flotta user:
`time="2022-04-27T06:31:32Z" level=warning msg="\"/\" is not a shared mount, this could cause issues or missing mounts with rootless containers"
Error: cannot setup namespace using newuidmap: exit status 1
`

Signed-off-by: Ondra Machacek <omachace@redhat.com>