### PR TITLE
Use custom XDG_RUNTIME_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,16 +117,16 @@ install-worker-config:
 	mkdir -p $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/workers/
 	mkdir -p $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/device/volumes
 	chown $(VOLUME_USER):$(VOLUME_USER) -R $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/device/volumes
-	sed 's,#LIBEXEC#,$(LIBEXECDIR),g;s,#HOME#,HOME=$(HOME),g' config/device-worker.toml > $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/workers/device-worker.toml
+	sed 's,#LIBEXEC#,$(LIBEXECDIR),g;s,#HOME#,HOME=$(HOME),g;s,#RUNTIME_DIR#,FLOTTA_XDG_RUNTIME_DIR=$(FLOTTA_XDG_RUNTIME_DIR),g' config/device-worker.toml > $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/workers/device-worker.toml
 
 install: ## Install device-worker with debug enabled
 install-debug: build-debug
-	sudo $(MAKE) install-worker-config HOME=$(HOME) VOLUME_USER=$(USER)
+	sudo $(MAKE) install-worker-config HOME=$(HOME) VOLUME_USER=$(USER) FLOTTA_XDG_RUNTIME_DIR=$(XDG_RUNTIME_DIR)
 	sudo install -D -m 755 ./bin/device-worker $(LIBEXECDIR)/yggdrasil/device-worker
 
 install: ## Install device-worker
 install: build
-	sudo $(MAKE) install-worker-config HOME=$(HOME) VOLUME_USER=$(USER)
+	sudo $(MAKE) install-worker-config HOME=$(HOME) VOLUME_USER=$(USER) FLOTTA_XDG_RUNTIME_DIR=$(XDG_RUNTIME_DIR)
 	sudo install -D -m 755 ./bin/device-worker $(LIBEXECDIR)/yggdrasil/device-worker
 
 install-arm64: ## Install device-worker on arm64.

--- a/cmd/device-worker/main.go
+++ b/cmd/device-worker/main.go
@@ -60,8 +60,9 @@ func main() {
 		baseDataDir = defaultDataDir
 	}
 
-	if flotta, err := user.Lookup("flotta"); err == nil {
-		if err = os.Setenv("XDG_RUNTIME_DIR", fmt.Sprintf("/run/user/%s", flotta.Uid)); err != nil {
+	// For RPM installation we stick with using flotta user:
+	if flotta, err := user.Lookup("flotta"); err == nil && os.Getenv("FLOTTA_XDG_RUNTIME_DIR") == "" {
+		if err = os.Setenv("FLOTTA_XDG_RUNTIME_DIR", fmt.Sprintf("/run/user/%s", flotta.Uid)); err != nil {
 			log.Warnf("Failed to set XDG_RUNTIME_DIR env var for flotta user. Podman/systemd may misbehave.")
 		}
 	}

--- a/config/device-worker.toml
+++ b/config/device-worker.toml
@@ -1,3 +1,3 @@
 exec = "#LIBEXEC#/yggdrasil/device-worker"
 protocol = "grpc"
-env = ["#HOME#"]
+env = ["#HOME#", "#RUNTIME_DIR#"]

--- a/flotta-agent.spec
+++ b/flotta-agent.spec
@@ -43,7 +43,7 @@ getent passwd %{flotta_user} >/dev/null || useradd -g %{flotta_user} -s /sbin/no
 %post
 systemctl enable --now nftables.service
 loginctl enable-linger %{flotta_user}
-XDG_RUNTIME_DIR="/run/user/$(getent passwd %{flotta_user} | cut -d: -f3)" su %{flotta_user} -s /bin/bash -c '/usr/bin/systemctl enable --user podman.socket'
+XDG_RUNTIME_DIR="/run/user/$(getent passwd %{flotta_user} | cut -d: -f3)" su %{flotta_user} -s /bin/bash -c '/usr/bin/systemctl enable --now --user podman.socket'
 
 %prep
 tar fx %{SOURCE0}

--- a/internal/service/systemd.go
+++ b/internal/service/systemd.go
@@ -140,8 +140,8 @@ func NewSystemd(name string, serviceNamePrefix string, units map[string]string) 
 
 func newDbusConnection() (*dbus.Conn, error) {
 	return dbus.NewConnection(func() (*godbus.Conn, error) {
-		uid := path.Base(os.Getenv("XDG_RUNTIME_DIR"))
-		path := filepath.Join(os.Getenv("XDG_RUNTIME_DIR"), "systemd/private")
+		uid := path.Base(os.Getenv("FLOTTA_XDG_RUNTIME_DIR"))
+		path := filepath.Join(os.Getenv("FLOTTA_XDG_RUNTIME_DIR"), "systemd/private")
 		conn, err := godbus.Dial(fmt.Sprintf("unix:path=%s", path))
 		if err != nil {
 			return nil, err

--- a/internal/workload/podman/podman.go
+++ b/internal/workload/podman/podman.go
@@ -121,7 +121,7 @@ func NewPodman() (*podman, error) {
 }
 
 func podmanConnection() (context.Context, error) {
-	podmanConnection, err := bindings.NewConnection(context.Background(), fmt.Sprintf("unix:%s/podman/podman.sock", os.Getenv("XDG_RUNTIME_DIR")))
+	podmanConnection, err := bindings.NewConnection(context.Background(), fmt.Sprintf("unix:%s/podman/podman.sock", os.Getenv("FLOTTA_XDG_RUNTIME_DIR")))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch add custom XDG_RUNTIME_DIR so user can customize it as
needed. For RPM installation we use flotta user XDG_RUNTIME_DIR env var
unless user overwrite it.

Signed-off-by: Ondra Machacek <omachace@redhat.com>