### PR TITLE
Don't generate _pod suffix for all pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	git.sr.ht/~spc/go-log v0.0.0-20210611184941-ce2f05edb627
 	github.com/apenella/go-ansible v1.1.5
 	github.com/aws/aws-sdk-go v1.42.16
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/containers/podman/v3 v3.4.3-0.20211216144417-90fb2cff071a
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/go-openapi/strfmt v0.21.1

--- a/internal/workload/podman/podman.go
+++ b/internal/workload/podman/podman.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/blang/semver"
 	"github.com/project-flotta/flotta-device-worker/internal/service"
 
 	"git.sr.ht/~spc/go-log"
@@ -55,6 +56,7 @@ WantedBy=default.target
 var (
 	logTailLines = "1"
 	boolTrue     = true
+	podmanV4, _  = semver.Make("4.0.0")
 )
 
 type AutoUpdateUnit struct {
@@ -358,6 +360,27 @@ func hasAutoUpdateEnabled(labels map[string]string) bool {
 	return false
 }
 
+func isPodNameSameAsCtrName(workload *v1.Pod, podName string) bool {
+	for _, ctr := range workload.Spec.Containers {
+		if podName == ctr.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *podman) podmanClientVersion() *semver.Version {
+	version, err := system.Version(p.podmanConnection, nil)
+	if err != nil {
+		return nil
+	}
+	sver, err := semver.Make(version.Client.Version)
+	if err != nil {
+		return nil
+	}
+	return &sver
+}
+
 func (p *podman) GenerateSystemdService(workload *v1.Pod, manifestPath string, monitoringInterval uint) (service.Service, error) {
 	var svc service.Service
 	podName := workload.Name
@@ -367,7 +390,16 @@ func (p *podman) GenerateSystemdService(workload *v1.Pod, manifestPath string, m
 	// autoupdate feature, because in case the image of the containers is updated we need to re-create the containers.
 	if !hasAutoUpdateEnabled(workload.Labels) {
 		useName := true
-		report, err := generate.Systemd(p.podmanConnection, podName+service.PodSuffix, &generate.SystemdOptions{RestartSec: &monitoringInterval, UseName: &useName})
+
+		var report *entities.GenerateSystemdReport
+		var err error
+
+		// More info: https://github.com/containers/podman/pull/12726
+		if sver := p.podmanClientVersion(); sver != nil && (*sver).LT(podmanV4) && isPodNameSameAsCtrName(workload, podName) {
+			report, err = generate.Systemd(p.podmanConnection, podName+service.PodSuffix, &generate.SystemdOptions{RestartSec: &monitoringInterval, UseName: &useName})
+		} else {
+			report, err = generate.Systemd(p.podmanConnection, podName, &generate.SystemdOptions{RestartSec: &monitoringInterval, UseName: &useName})
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,6 +117,7 @@ github.com/beorn7/perks/quantile
 # github.com/bits-and-blooms/bitset v1.2.0
 github.com/bits-and-blooms/bitset
 # github.com/blang/semver v3.5.1+incompatible
+## explicit
 github.com/blang/semver
 # github.com/cespare/xxhash/v2 v2.1.2
 github.com/cespare/xxhash/v2


### PR DESCRIPTION
Add _pod suffix for pods only in case podman version is less then 4.0
and only in case the pod and container names are the same.

Signed-off-by: Ondra Machacek <omachace@redhat.com>