### PR TITLE
Build test container image for each PR

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,54 @@
+---
+name: Container build
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  rpm:
+    name: Build rpm
+    container: fedora:latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out proper version of sources
+        uses: actions/checkout@v1
+
+      - name: Install tooling for source RPM build
+        run: |
+          dnf -y install @development-tools @rpm-development-tools
+          dnf -y install copr-cli make golang
+
+      - name: Build the RPM
+        run: |
+          make rpm-tarball
+          make rpm-src
+          make rpm
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: flotta-agent-rpm
+          path: "/github/home/rpmbuild/RPMS/x86_64/"
+
+  container:
+    runs-on: ubuntu-latest
+    needs: rpm
+    steps:
+      - name: Check out proper version of sources
+        uses: actions/checkout@v1
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: flotta-agent-rpm
+          path: tools/
+
+      - name: Build the container image
+        run: |
+          docker build --build-arg quay_expiration=1d --build-arg flotta_agent_rpm=flotta-agent-race*.rpm ./tools/ -t edgedevice
+
+      - name: Upload image
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: edgedevice

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ bin
 # Coverage
 gover.coverprofile
 *.coverprofile
+
+# RPM
+*.tar.gz
+*.rpm

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,19 +1,26 @@
 FROM quay.io/podman/stable:v3.4.4
 
+ARG quay_expiration=never
+ARG flotta_agent_rpm=flotta-agent-rpm
+LABEL maintainer="flotta@redhat.com" quay.expires-after=${quay_expiration}
+
 WORKDIR /project
+COPY . .
+
 RUN dnf install -y 'dnf-command(copr)'
 RUN dnf copr enable project-flotta/flotta -y
 
 # Yum dependencies
 RUN dnf update -y \
   && dnf install -y openssl procps-ng dmidecode nc iproute \
-  yggdrasil flotta-agent-race node_exporter
+  yggdrasil node_exporter
+
+RUN dnf install -y ${flotta_agent_rpm}
 
 # Modify podman configuration
 RUN sed -i s/netns=\"host\"/netns=\"private\"/g /etc/containers/containers.conf && \
-    sed -i s/utsns=\"host\"/utsns=\"private\"/g /etc/containers/containers.conf
-
-RUN podman pull quay.io/project-flotta/nginx:1.21.6
+    sed -i s/utsns=\"host\"/utsns=\"private\"/g /etc/containers/containers.conf && \
+    sed -i s/ipcns=\"host\"/ipcns=\"private\"/g /etc/containers/containers.conf
 
 # Certificate reqs:
 RUN mkdir /etc/pki/consumer && \


### PR DESCRIPTION
This PR add a workflow job, that build the test container for each PR.

Every container will be stored as zipped artifact. You can later use this artifact to run manual workflow job in `flotta-operator` repo to test the your code with our e2e tests.

Signed-off-by: Ondra Machacek <omachace@redhat.com>