### PR TITLE
Add RPM req for ansible and node_exporter

### DIFF
--- a/flotta-agent.spec
+++ b/flotta-agent.spec
@@ -11,7 +11,9 @@ Source0:    %{name}-%{version}.tar.gz
 
 BuildRequires:  golang
 
+Requires:       ansible
 Requires:       nftables
+Requires:       node_exporter
 Requires:       podman
 Requires:       yggdrasil
 


### PR DESCRIPTION
Since we do support metrics and ansible, we should require dependencies so the features work. We print warnings when those features don't work if those packages are not installed, but we don't provide any documentation to add it add hoc. So would be better to require it during installation.

Signed-off-by: Ondra Machacek <omachace@redhat.com>