### PR TITLE
Fix datarace when deregister and refactor

### DIFF
--- a/internal/registration/certs.go
+++ b/internal/registration/certs.go
@@ -51,12 +51,12 @@ func (c *ClientCert) init() error {
 
 func (c *ClientCert) IsRegisterCert() (bool, error) {
 	if c.certGroup == nil {
-		return false, errors.New("Certificates are not imported")
+		return false, errors.New("certificates are not imported")
 	}
 
 	cert := c.certGroup.GetCert()
 	if cert == nil {
-		return false, errors.New("No valid cert")
+		return false, errors.New("no valid cert")
 	}
 
 	return cert.Subject.CommonName == mtls.CertRegisterCN, nil

--- a/internal/registration/registration.go
+++ b/internal/registration/registration.go
@@ -294,6 +294,8 @@ func (r *Registration) Deregister() error {
 		}
 	}
 
+	r.lock.RLock()
+	defer r.lock.RUnlock()
 	r.registered = false
 	return errors
 }

--- a/internal/registration/registration_test.go
+++ b/internal/registration/registration_test.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	osUtil "os"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -63,7 +63,7 @@ var _ = Describe("Registration", func() {
 		datadir, err = ioutil.TempDir("", "registrationTest")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = osUtil.MkdirAll(sysconfigPath, osUtil.ModePerm)
+		err = os.MkdirAll(sysconfigPath, os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 
 		mockCtrl = gomock.NewController(GinkgoT())
@@ -105,10 +105,10 @@ var _ = Describe("Registration", func() {
 
 	AfterEach(func() {
 		mockCtrl.Finish()
-		_ = osUtil.Remove(datadir)
-		_ = osUtil.Remove(sysconfigPath)
-		_ = osUtil.Remove(regCertPath)
-		_ = osUtil.Remove(regKeyPath)
+		_ = os.Remove(datadir)
+		_ = os.Remove(sysconfigPath)
+		_ = os.Remove(regCertPath)
+		_ = os.Remove(regKeyPath)
 
 	})
 

--- a/internal/registration/registration_test.go
+++ b/internal/registration/registration_test.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"os"
 	osUtil "os"
 	"path/filepath"
 	"time"
@@ -64,7 +63,7 @@ var _ = Describe("Registration", func() {
 		datadir, err = ioutil.TempDir("", "registrationTest")
 		Expect(err).ToNot(HaveOccurred())
 
-		err = os.MkdirAll(sysconfigPath, os.ModePerm)
+		err = osUtil.MkdirAll(sysconfigPath, osUtil.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 
 		mockCtrl = gomock.NewController(GinkgoT())
@@ -607,10 +606,10 @@ func (regMatcher) String() string {
 }
 
 type certificate struct {
-	cert       *x509.Certificate
 	key        crypto.Signer
-	certBytes  []byte
+	cert       *x509.Certificate
 	signedCert *x509.Certificate
+	certBytes  []byte
 }
 
 func (c *certificate) DumpToFiles(certPath, keyPath string) ([]byte, []byte) {
@@ -679,7 +678,7 @@ func createGivenClientCert(cert *x509.Certificate, ca *certificate) *certificate
 	err = signedCert.CheckSignatureFrom(ca.signedCert)
 	ExpectWithOffset(1, err).To(BeNil(), "Fail on check signature")
 
-	return &certificate{cert, certKey, certBytes, signedCert}
+	return &certificate{certKey, cert, signedCert, certBytes}
 }
 
 func createCACert() *certificate {
@@ -709,5 +708,5 @@ func createCACertUsingKey(key crypto.Signer) *certificate {
 	signedCert, err := x509.ParseCertificate(caBytes)
 	ExpectWithOffset(1, err).To(BeNil(), "Fail on parsing certificate")
 
-	return &certificate{ca, key, caBytes, signedCert}
+	return &certificate{key, ca, signedCert, caBytes}
 }


### PR DESCRIPTION
This PR fixes the datarace when deregistering device detected byu  @jakub-dzon 

Basic refactoring was also performed:
- split methods into smaller methods
- reorganized/realigned structs fields of the registration package
- fix warnings

Signed-off-by: Gabriel Farache [gfarache@redhat.com](mailto:gfarache@redhat.com)