### PR TITLE
Rootless podman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@ bin
 gover.coverprofile
 *.coverprofile
 
-# rpm
+# RPM
 *.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ gosec: ## Run gosec locally
 
 test: ## Run unit test on device worker
 test: test-tools
-	$(GINKGO)  --race -r $(GINKGO_OPTIONS) ./internal/* ./cmd/*
+	$(GINKGO) --race -r $(GINKGO_OPTIONS) ./internal/* ./cmd/*
 
 test-coverage:
 test-coverage: ## Run test and launch coverage tool
@@ -114,16 +114,18 @@ build-arm64: ## Build device worker for arm64
 
 install-worker-config:
 	mkdir -p $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/workers/
-	sed 's,#LIBEXEC#,$(LIBEXECDIR),g' config/device-worker.toml > $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/workers/device-worker.toml
+	mkdir -p $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/device/volumes
+	chown $(VOLUME_USER):$(VOLUME_USER) -R $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/device/volumes
+	sed 's,#LIBEXEC#,$(LIBEXECDIR),g;s,#HOME#,HOME=$(HOME),g;s,#RUNTIME_DIR#,FLOTTA_XDG_RUNTIME_DIR=$(FLOTTA_XDG_RUNTIME_DIR),g' config/device-worker.toml > $(BUILDROOT)$(SYSCONFDIR)/yggdrasil/workers/device-worker.toml
 
 install: ## Install device-worker with debug enabled
 install-debug: build-debug needs-root
-	$(MAKE) install-worker-config
+	$(MAKE) install-worker-config HOME=$(HOME) VOLUME_USER=$(USER) FLOTTA_XDG_RUNTIME_DIR=$(XDG_RUNTIME_DIR)
 	install -D -m 755 ./bin/device-worker $(LIBEXECDIR)/yggdrasil/device-worker
 
 install: ## Install device-worker
 install: build needs-root
-	$(MAKE) install-worker-config
+	$(MAKE) install-worker-config HOME=$(HOME) VOLUME_USER=$(USER) FLOTTA_XDG_RUNTIME_DIR=$(XDG_RUNTIME_DIR)
 	install -D -m 755 ./bin/device-worker $(LIBEXECDIR)/yggdrasil/device-worker
 
 install-arm64: ## Install device-worker on arm64.

--- a/config/device-worker.toml
+++ b/config/device-worker.toml
@@ -1,3 +1,3 @@
 exec = "#LIBEXEC#/yggdrasil/device-worker"
 protocol = "grpc"
-env = []
+env = ["#HOME#", "#RUNTIME_DIR#"]

--- a/flotta-agent.spec
+++ b/flotta-agent.spec
@@ -1,5 +1,7 @@
 %define _build_id_links none
 
+%global flotta_user flotta
+
 Name:       flotta-agent
 Version:    0.1.0
 Release:    1%{?dist}
@@ -17,6 +19,8 @@ Requires:       node_exporter
 Requires:       podman
 Requires:       yggdrasil
 
+Requires(pre): shadow-utils
+
 Provides:       %{name} = %{version}-%{release}
 Provides:       golang(%{go_import_path}) = %{version}-%{release}
 
@@ -30,9 +34,19 @@ to detect race-conditions in the e2e test
 %description
 The Flotta agent communicates with the Flotta control plane. It reports the status of the appliance and of the running PODs/containers. Agent is responsible for starting and stopping PODs that are based on commands from the control plane.
 
+%pre race
+getent group %{flotta_user} >/dev/null || groupadd %{flotta_user}; \
+getent passwd %{flotta_user} >/dev/null || useradd -g %{flotta_user} -s /sbin/nologin -d /home/%{flotta_user} %{flotta_user}
+
+%pre
+getent group %{flotta_user} >/dev/null || groupadd %{flotta_user}; \
+getent passwd %{flotta_user} >/dev/null || useradd -g %{flotta_user} -s /sbin/nologin -d /home/%{flotta_user} %{flotta_user}
+
 %post
-systemctl enable --now podman.socket
 systemctl enable --now nftables.service
+loginctl enable-linger %{flotta_user}
+systemctl start user@$(getent passwd %{flotta_user} | cut -d: -f3).service
+systemctl --machine %{flotta_user}@.host --user start podman.socket
 
 %prep
 tar fx %{SOURCE0}
@@ -49,17 +63,23 @@ cd flotta-agent-%{VERSION}
 mkdir -p %{buildroot}%{_libexecdir}/yggdrasil/
 install ./bin/device-worker %{buildroot}%{_libexecdir}/yggdrasil/device-worker
 install ./bin/device-worker-race %{buildroot}%{_libexecdir}/yggdrasil/device-worker-race
-make install-worker-config LIBEXECDIR=%{_libexecdir} BUILDROOT=%{buildroot} SYSCONFDIR=%{_sysconfdir}
+make install-worker-config HOME=/home/%{flotta_user} LIBEXECDIR=%{_libexecdir} BUILDROOT=%{buildroot} SYSCONFDIR=%{_sysconfdir}
 
 %files
 %{_libexecdir}/yggdrasil/device-worker
 %{_sysconfdir}/yggdrasil/
+%dir %attr(0755, %{flotta_user}, %{flotta_user}) %{_sysconfdir}/yggdrasil/device/volumes
 
 %files race
 %{_libexecdir}/yggdrasil/device-worker-race
 %{_sysconfdir}/yggdrasil/
+%dir %attr(0755, %{flotta_user}, %{flotta_user}) %{_sysconfdir}/yggdrasil/device/volumes
 
 %post race
+loginctl enable-linger %{flotta_user}
+systemctl start user@$(getent passwd %{flotta_user} | cut -d: -f3).service
+systemctl --machine %{flotta_user}@.host --user start podman.socket
+systemctl enable --now nftables.service
 ln -sf %{_libexecdir}/yggdrasil/device-worker-race %{_libexecdir}/yggdrasil/device-worker
 
 %changelog

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containers/podman/v3 v3.4.3-0.20211216144417-90fb2cff071a
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/go-openapi/strfmt v0.21.1
+	github.com/godbus/dbus/v5 v5.0.6
 	github.com/golang/mock v1.6.0
 	github.com/golang/snappy v0.0.4
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1836,8 +1836,6 @@ github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stripe/safesql v0.2.0/go.mod h1:q7b2n0JmzM1mVGfcYpanfVb2j23cXZeWFxcILPn3JV4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/internal/metrics/system.go
+++ b/internal/metrics/system.go
@@ -26,7 +26,7 @@ type SystemMetrics struct {
 }
 
 func NewSystemMetrics(daemon MetricsDaemon) (*SystemMetrics, error) {
-	nodeExporter, err := service.NewSystemdWithSuffix("node_exporter", "", "", service.ServiceSuffix, nil)
+	nodeExporter, err := service.NewSystemdWithSuffix("node_exporter", "", "", service.ServiceSuffix, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workload/wrapper.go
+++ b/internal/workload/wrapper.go
@@ -130,7 +130,7 @@ func (ww *Workload) RegisterObserver(observer Observer) {
 
 func (ww *Workload) Init() error {
 	// Enable auto-update podman timer:
-	svc, err := service.NewSystemdWithSuffix("podman-auto-update", "", "", service.TimerSuffix, nil)
+	svc, err := service.NewSystemdWithSuffix("podman-auto-update", "", "", service.TimerSuffix, nil, false)
 	if err != nil {
 		return err
 	}
@@ -283,9 +283,8 @@ func (ww *Workload) createService(svc service.Service) error {
 	if err := svc.Enable(); err != nil {
 		return err
 	}
-	if err := svc.Start(); err != nil {
-		return err
-	}
+
+	_ = svc.Start()
 
 	return nil
 }

--- a/internal/workload/wrapper_test.go
+++ b/internal/workload/wrapper_test.go
@@ -102,8 +102,7 @@ var _ = Describe("Workload management", func() {
 			newPodman.EXPECT().GenerateSystemdService(pod, gomock.Any(), gomock.Any()).Return(svc, nil)
 
 			svc.EXPECT().Add().Return(nil)
-			svc.EXPECT().Enable().Return(nil)
-			svc.EXPECT().Start().Return(fmt.Errorf("Failed to add service"))
+			svc.EXPECT().Enable().Return(fmt.Errorf("Failed to add service"))
 
 			// when
 			err := wk.Run(pod, manifestPath, authFilePath)

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -14,8 +14,6 @@ RUN sed -i s/netns=\"host\"/netns=\"private\"/g /etc/containers/containers.conf 
     sed -i s/utsns=\"host\"/utsns=\"private\"/g /etc/containers/containers.conf && \
     sed -i s/ipcns=\"host\"/ipcns=\"private\"/g /etc/containers/containers.conf
 
-RUN podman pull quay.io/project-flotta/nginx:1.21.6
-
 # Certificate reqs:
 RUN mkdir /etc/pki/consumer && \
     openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -out cert.pem -keyout key.pem -subj "/C=EU/ST=No/L=State/O=D/CN=www.example.com" && \

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -414,6 +414,7 @@ github.com/go-openapi/validate
 # github.com/go-stack/stack v1.8.0
 github.com/go-stack/stack
 # github.com/godbus/dbus/v5 v5.0.6
+## explicit
 github.com/godbus/dbus/v5
 # github.com/gogo/protobuf v1.3.2
 github.com/gogo/protobuf/gogoproto


### PR DESCRIPTION
This commit add support for rootless podman.

There are multiple things needed to support rootless podman:
 0) Create a user running the podman, flotta in our case.
 1) Enable linger for the user, so systemd can run even without session.
 2) Have set the /etc/subuid /etc/subgid for the user.
 3) Create home directory for the user, to store the data and systemd
    services.
 4) Enable podman.socket for the user.
 5) Volumes director must be owned by the user, as podman use it, not
    root.

Those prerequsites are done in spec file. For RPM based installation by
default the device-worker will execute podman as rootless. For dev-env
user will still use the rootfull pods. This could be changed the env
variables in the 'config/device-worker.toml'. We introduced two new env
variables:

  - HOME - store the home directory of the user
  - FLOTTA_XDG_RUNTIME_DIR - store the runtime dir of the user

FLOTTA_XDG_RUNTIME_DIR must be set for podman to properly work, this variable
is set by pam_systemd module, which is not used, as we don't switch the
user, we only use the podman socket of the user and the DBus connection,
which needs the env var as well.

The home directory is used for storing the podman data, and systemd
services.

The volume directory which is used by podman, must be owned by the user
which is manipulating the pods/containers, so that's done by Makefile
script.

Note the known limitation of rootless podman: https://github.com/containers/podman/blob/main/rootless.md

Signed-off-by: Ondra Machacek <omachace@redhat.com>