### PR TITLE
do not close channels in function conatinerLog

### DIFF
--- a/internal/workload/podman/podman.go
+++ b/internal/workload/podman/podman.go
@@ -515,8 +515,6 @@ func (p *podman) containerLog(ctx context.Context, containerID string, res io.Wr
 					log.Errorf("cannot write log line to io.Writer for container '%v': %v", containerID, err)
 				}
 			case <-ctx.Done():
-				close(stderrCh)
-				close(stdoutCh)
 				return
 			}
 		}


### PR DESCRIPTION
it is better to avoid closing channels

https://issues.redhat.com/browse/ECOPROJECT-837
Signed-off-by: Yaron Dayagi <ydayagi@redhat.com>