### PR TITLE
removing log and struct field

### DIFF
--- a/internal/metrics/workload.go
+++ b/internal/metrics/workload.go
@@ -16,7 +16,6 @@ const (
 )
 
 type WorkloadMetrics struct {
-	latestConfig   models.WorkloadList
 	daemon         MetricsDaemon
 	workloadConfig map[string]*models.Workload
 	lock           sync.RWMutex
@@ -44,9 +43,7 @@ func (wrkM *WorkloadMetrics) Update(config models.DeviceConfigurationMessage) er
 
 	wrkM.lock.Lock()
 	defer wrkM.lock.Unlock()
-	wrkM.latestConfig = config.Workloads
 	wrkM.workloadConfig = cfg
-	log.Infof("metrics workload config update: %+v", cfg)
 	return nil
 }
 


### PR DESCRIPTION
the fiels latestConfig is not used
the log line prints the pointer addresses upon every call to Update
https://issues.redhat.com/browse/ECOPROJECT-829

Signed-off-by: Yaron Dayagi <ydayagi@redhat.com>