### PR TITLE
Bump _go_ version from 1.16.15 to 1.17.11 in github/workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.15
+        go-version: 1.17.11
 
     - name: Install package
       run: |


### PR DESCRIPTION
Signed-off-by: Cosmin Tupangiu <cosmin@redhat.com>