### PR TITLE
Fix issues with running device-worker

### DIFF
--- a/cmd/device-worker/main.go
+++ b/cmd/device-worker/main.go
@@ -41,7 +41,7 @@ const (
 func initSystemdDirectory() error {
 	systemddir := filepath.Join(os.Getenv("HOME"), ".config/systemd/user/")
 	// init the flotta user systemd units directory
-	err := os.MkdirAll(systemddir, 0644)
+	err := os.MkdirAll(systemddir, 0750)
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func initSystemdDirectory() error {
 }
 
 func main() {
-	log.SetFlags(0) // No datatime, is already done on yggradsil server
+	log.SetFlags(0) // No datetime, is already done on yggdrasil server
 
 	logLevel, ok := os.LookupEnv("YGG_LOG_LEVEL")
 	if !ok {

--- a/flotta-agent.spec
+++ b/flotta-agent.spec
@@ -45,8 +45,12 @@ getent passwd %{flotta_user} >/dev/null || useradd -g %{flotta_user} -s /sbin/no
 %post
 systemctl enable --now nftables.service
 loginctl enable-linger %{flotta_user}
-systemctl start user@$(getent passwd %{flotta_user} | cut -d: -f3).service
-systemctl --machine %{flotta_user}@.host --user start podman.socket
+
+# HACK till https://bugzilla.redhat.com/show_bug.cgi?id=2060702 is fixed
+setenforce 0
+systemctl enable --now --machine %{flotta_user}@.host --user podman.socket
+setenforce 1
+# END HACK
 
 %prep
 tar fx %{SOURCE0}
@@ -77,8 +81,13 @@ make install-worker-config USER=%{flotta_user} HOME=/home/%{flotta_user} LIBEXEC
 
 %post race
 loginctl enable-linger %{flotta_user}
-systemctl start user@$(getent passwd %{flotta_user} | cut -d: -f3).service
-systemctl --machine %{flotta_user}@.host --user start podman.socket
+
+# HACK till https://bugzilla.redhat.com/show_bug.cgi?id=2060702 is fixed
+setenforce 0
+systemctl enable --now --machine %{flotta_user}@.host --user podman.socket
+setenforce 1
+# END HACK
+
 systemctl enable --now nftables.service
 ln -sf %{_libexecdir}/yggdrasil/device-worker-race %{_libexecdir}/yggdrasil/device-worker
 


### PR DESCRIPTION
The PR fixes several issues with device-worker:
* It adds executable permissions to .config folder:
  Without +x, no access can be made to the folder and files cannot be
  created in.
* Uses `id -u flotta` to obtain flotta user ID.
* Disables selinux as a workaround to failure to start podman.socket as
  flotta user. This issue is reported in
  bug https://bugzilla.redhat.com/show_bug.cgi?id=2060702
* Remove `systemctl user@...` since user systemd is controller by
  loginctl.

Signed-off-by: Moti Asayag <masayag@redhat.com>