### PR TITLE
fix panic/crash when deleting workload

### DIFF
--- a/internal/metrics/system.go
+++ b/internal/metrics/system.go
@@ -26,10 +26,7 @@ type SystemMetrics struct {
 }
 
 func NewSystemMetrics(daemon MetricsDaemon) (*SystemMetrics, error) {
-	nodeExporter, err := service.NewSystemdWithSuffix("node_exporter", "", "", service.ServiceSuffix, nil, false)
-	if err != nil {
-		return nil, err
-	}
+	nodeExporter := service.NewSystemdWithSuffix("node_exporter", "", "", service.ServiceSuffix, nil, false)
 	return NewSystemMetricsWithNodeExporter(daemon, nodeExporter), nil
 }
 

--- a/internal/workload/podman/podman.go
+++ b/internal/workload/podman/podman.go
@@ -407,10 +407,8 @@ func (p *podman) GenerateSystemdService(workload *v1.Pod, manifestPath string, m
 			return nil, err
 		}
 
-		svc, err = service.NewSystemdWithSuffix(podName, service.ServicePrefix, suffix, service.ServiceSuffix, report.Units, true)
-		if err != nil {
-			return nil, err
-		}
+		svc = service.NewSystemdWithSuffix(podName, service.ServicePrefix, suffix, service.ServiceSuffix, report.Units, true)
+
 	} else {
 		var unit bytes.Buffer
 
@@ -424,10 +422,7 @@ func (p *podman) GenerateSystemdService(workload *v1.Pod, manifestPath string, m
 			return nil, err
 		}
 		units := map[string]string{service.ServicePrefix + podName: unit.String()}
-		svc, err = service.NewSystemd(podName, service.ServicePrefix, units)
-		if err != nil {
-			return nil, err
-		}
+		svc = service.NewSystemd(podName, service.ServicePrefix, units)
 	}
 
 	return svc, nil

--- a/internal/workload/wrapper.go
+++ b/internal/workload/wrapper.go
@@ -130,14 +130,12 @@ func (ww *Workload) RegisterObserver(observer Observer) {
 
 func (ww *Workload) Init() error {
 	// Enable auto-update podman timer:
-	svc, err := service.NewSystemdWithSuffix("podman-auto-update", "", "", service.TimerSuffix, nil, false)
-	if err != nil {
+	svc := service.NewSystemdWithSuffix("podman-auto-update", "", "", service.TimerSuffix, nil, false)
+
+	if err := svc.Enable(); err != nil {
 		return err
 	}
-	if err = svc.Enable(); err != nil {
-		return err
-	}
-	if err = svc.Start(); err != nil {
+	if err := svc.Start(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
systemd struct has a field of type pointer to dbus conneciton
it is only assigned when creating a workload
however, it is used when deleting/updating a workload and upon startup
If you create a workload, restart the device-worker, update/delete a workload
then the device-worker will crash.

https://issues.redhat.com/browse/ECOPROJECT-859
Signed-off-by: Yaron Dayagi <ydayagi@redhat.com>