### PR TITLE
Add target to run rootfull test container

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,6 +29,10 @@ jobs:
       run: |
         make test
 
+    - name: Test in rootful container
+      run: |
+        make test-docker
+
     - name: Checking generated files are up to date
       run: git diff --quiet internal/ || (echo "There are not committed changes"; git diff internal/| tee; exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,12 @@ test: ## Run unit test on device worker
 test: test-tools
 	$(GINKGO) --race -r $(GINKGO_OPTIONS) ./internal/* ./cmd/*
 
+TEST_IMAGE_NAME ?= device-worker-test
+TEST_IMAGE_TAG ?= latest
+test-docker:
+	$(DOCKER) build tools/ -f Dockerfile_test -t $(TEST_IMAGE_NAME):$(TEST_IMAGE_TAG)
+	$(DOCKER) run -v $(PWD):/device-worker --rm $(TEST_IMAGE_NAME):$(TEST_IMAGE_TAG)
+
 test-coverage:
 test-coverage: ## Run test and launch coverage tool
 test-coverage: GINKGO_OPTIONS ?= --cover

--- a/internal/common/test_utils.go
+++ b/internal/common/test_utils.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+func checkReason(reason string) {
+	if len(reason) < 5 {
+		panic("Test must specify a reason to skip")
+	}
+}
+
+func SkipIfRootless(reason string) {
+	checkReason(reason)
+	if os.Geteuid() != 0 {
+		Skip("[rootless]: " + reason)
+	}
+
+}
+func IsContainerized() bool {
+	// This is for docker
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+
+	// This is set to "podman" by podman automatically
+	return os.Getenv("container") != ""
+}

--- a/internal/configuration/configuration_test.go
+++ b/internal/configuration/configuration_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/project-flotta/flotta-device-worker/internal/common"
 	"github.com/project-flotta/flotta-device-worker/internal/configuration"
 	"github.com/project-flotta/flotta-operator/models"
 )
@@ -208,8 +209,16 @@ var _ = Describe("Configuration", func() {
 		It("Cannot write device config", func() {
 
 			// given
-			err = os.Chmod(datadir, 0444)
-			Expect(err).NotTo(HaveOccurred())
+			if common.IsContainerized() {
+				err = os.RemoveAll(datadir)
+				Expect(err).NotTo(HaveOccurred())
+				defer func() {
+					_ = os.Mkdir(datadir, 0777)
+				}()
+			} else {
+				err = os.Chmod(datadir, 0444)
+				Expect(err).NotTo(HaveOccurred())
+			}
 
 			configManager := configuration.NewConfigurationManager(datadir)
 
@@ -578,8 +587,16 @@ var _ = Describe("Configuration", func() {
 
 			deviceConfigExists()
 
-			err = os.Chmod(datadir, 0444)
-			Expect(err).NotTo(HaveOccurred())
+			if common.IsContainerized() {
+				err = os.RemoveAll(datadir)
+				Expect(err).NotTo(HaveOccurred())
+				defer func() {
+					_ = os.Mkdir(datadir, 0777)
+				}()
+			} else {
+				err = os.Chmod(datadir, 0444)
+				Expect(err).NotTo(HaveOccurred())
+			}
 
 			// when
 			err = configManager.Deregister()

--- a/internal/workload/manager_test.go
+++ b/internal/workload/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/project-flotta/flotta-device-worker/internal/common"
 	"github.com/project-flotta/flotta-device-worker/internal/workload"
 	api "github.com/project-flotta/flotta-device-worker/internal/workload/api"
 	"github.com/project-flotta/flotta-operator/models"
@@ -141,6 +142,10 @@ var _ = Describe("Manager", func() {
 			datadir, err = ioutil.TempDir("", "worloadTest")
 			err = os.Chmod(datadir, 0444)
 			Expect(err).NotTo(HaveOccurred())
+
+			if common.IsContainerized() {
+				datadir = "/sys" // set to /sys which is always readonly
+			}
 
 			// When
 			wkManager, err = workload.NewWorkloadManagerWithParams(datadir, wkwMock, deviceId)

--- a/tools/Dockerfile_test
+++ b/tools/Dockerfile_test
@@ -1,0 +1,10 @@
+FROM fedora:36
+
+RUN dnf install -y git make which go ansible btrfs-progs-devel device-mapper device-mapper-devel
+
+ARG GINKGO_VERS=v2.1.3
+RUN go install github.com/onsi/ginkgo/v2/ginkgo@${GINKGO_VERS}
+
+WORKDIR /device-worker
+
+ENTRYPOINT ["/bin/bash", "-c", "make test"]


### PR DESCRIPTION
This PR adds a new target `test-docker` which executes all the test in a rootfull contiainer.