### PR TITLE
RPM: Ostree changes 🚀

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION = 0.1.0
-RELEASE = 1
+RELEASE = 2
 DIST_DIR = $(shell pwd)/dist
 CGO_ENABLED = 0
 OS :=$(shell awk -F= '/^ID/{print $$2}' /etc/os-release)

--- a/packaging/systemd/flotta-agent.sysusers
+++ b/packaging/systemd/flotta-agent.sysusers
@@ -1,0 +1,2 @@
+#Type Name    ID  GECOS                 Home directory    Shell
+u     flotta  -   "Flotta device"       /var/home/flotta  /sbin/nologin

--- a/packaging/systemd/flotta.conf
+++ b/packaging/systemd/flotta.conf
@@ -1,0 +1,3 @@
+F /var/lib/systemd/linger/flotta 0755 root root
+L /var/home/flotta/.config/systemd/user/sockets.target.wants/podman.socket 0777 flotta flotta - /usr/lib/systemd/user/podman.socket
+d /etc/yggdrasil/device/volumes 0777 flotta flotta - 


### PR DESCRIPTION
When running on Ostree base operation system, wrting to /var is not
allowed at all, and things like enable linger for flotta agent is
not possible.

At the same time creating folders for user flotta was difficult because
when running it flotta user is not in place yet.

With this change, flotta-agent rpm is compatible with ostree OS, in this
case Red Hat enterprise Linux for Edge.

The main changes are:

- Adding sysusers.d file to enable users.
- Adding /etc/tmpfiles.d config to create files based on systemd

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>