### PR TITLE
RPM: Add flotta home folder on tmpfiles

### DIFF
--- a/packaging/systemd/flotta.conf
+++ b/packaging/systemd/flotta.conf
@@ -1,3 +1,4 @@
 F /var/lib/systemd/linger/flotta 0755 root root
 L /var/home/flotta/.config/systemd/user/sockets.target.wants/podman.socket 0777 flotta flotta - /usr/lib/systemd/user/podman.socket
-d /etc/yggdrasil/device/volumes 0777 flotta flotta - 
+d /etc/yggdrasil/device/volumes 0777 flotta flotta -
+d /var/home/flotta 0777 flotta flotta -


### PR DESCRIPTION
This change adds the home user that it's own by the flotta user.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>