### PR TITLE
RPM: systemd service for creating users

### DIFF
--- a/packaging/systemd/flotta-agent.service
+++ b/packaging/systemd/flotta-agent.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Create flotta user
+Before=systemd-logind.service
+Before=podman.service
+Before=yggdrasild.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=bash -c "getent group flotta >/dev/null || groupadd flotta"
+ExecStart=bash -c "getent passwd flotta >/dev/null || useradd -g flotta -s /sbin/nologin -d /var/home/flotta flotta"
+TimeoutSec=90s
+
+[Install]
+WantedBy=sysinit.target
+

--- a/packaging/systemd/flotta-agent.sysusers
+++ b/packaging/systemd/flotta-agent.sysusers
@@ -1,2 +1,0 @@
-#Type Name    ID  GECOS                 Home directory    Shell
-u     flotta  -   "Flotta device"       /var/home/flotta  /sbin/nologin


### PR DESCRIPTION
When enabling sysusers.d on commit
5b66ac05fc27f4a08be7ae4a28a629fde6d60ea3  flotta user was created, but
the user was system and the entries on /etc/subgid was not created at
all.

With this change, a new system unit file will be created just before
systemd logind service, so user is created and lingered on the first
boot.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>