### PR TITLE
RPM: Fix rhel build

### DIFF
--- a/flotta-agent.spec
+++ b/flotta-agent.spec
@@ -14,7 +14,9 @@ Source0:    %{name}-%{version}.tar.gz
 BuildRequires:  golang
 BuildRequires:  systemd-rpm-macros
 BuildRequires:  bash
-BuildRequires:  btrfs-progs-devel
+%if 0%{?fedora} && ! 0%{?rhel}
+BuildRequires: btrfs-progs-devel
+%endif
 BuildRequires:  device-mapper-devel
 
 %if 0%{?rhel}
@@ -44,6 +46,12 @@ The Flotta agent communicates with the Flotta control plane. It reports the stat
 
 %prep
 tar fx %{SOURCE0}
+
+# RHEL does not support btrfs
+# https://github.com/containers/podman/blob/948c5e915aec709beb4e171a72c7e54504889baf/podman.spec.rpkg#L162-L164
+%if 0%{?rhel}
+rm -rf vendor/github.com/containers/storage/drivers/register/register_btrfs.go
+%endif
 
 %build
 cd flotta-agent-%{VERSION}


### PR DESCRIPTION
On comit e1f0e79f554bfb43c51733a21f2d10b52f960c3b a new dependency was
added, but does not work for rhel base system, with this changes new
COPR builds should work as normal

Failed builds:
https://copr.fedorainfracloud.org/coprs/project-flotta/flotta-testing/build/4565976/
https://copr.fedorainfracloud.org/coprs/project-flotta/flotta-testing/build/4565980/
https://copr.fedorainfracloud.org/coprs/project-flotta/flotta-testing/build/4566089/

Same behaviour as podman:
https://github.com/containers/podman/blob/948c5e915aec709beb4e171a72c7e54504889baf/podman.spec.rpkg#L162-L164

And we only use because of podman:

```
$ -> go mod why github.com/containers/storage/drivers/btrfs
github.com/project-flotta/flotta-device-worker/internal/workload/podman
github.com/containers/podman/v3/pkg/bindings/containers
github.com/containers/podman/v3/pkg/specgen
github.com/containers/storage
github.com/containers/storage/drivers/register
github.com/containers/storage/drivers/btrfs
$ ->
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>