### PR TITLE
Fix: Run tmpfiles on flotta-agent service

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install tooling for source RPM build
         run: |
           dnf -y install @development-tools @rpm-development-tools
-          dnf -y install copr-cli make
+          dnf -y install copr-cli make jq
 
       - name: Check out proper version of sources
         uses: actions/checkout@v3

--- a/packaging/systemd/flotta-agent.service
+++ b/packaging/systemd/flotta-agent.service
@@ -9,6 +9,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=bash -c "getent group flotta >/dev/null || groupadd flotta"
 ExecStart=bash -c "getent passwd flotta >/dev/null || useradd -g flotta -s /sbin/nologin -d /var/home/flotta flotta"
+ExecStartPost=systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
 TimeoutSec=90s
 
 [Install]


### PR DESCRIPTION


Because now the tmpfiles are trying to use flotta user, but we cannot
use sysusers anymore it's failing on the first boot and the flotta user
cannot run podman socket. This PR fix the flotta unit to create folders.
