### PR TITLE
Folders: Enable full write permissions

### DIFF
--- a/internal/workload/manager.go
+++ b/internal/workload/manager.go
@@ -54,12 +54,14 @@ func NewWorkloadManagerWithParams(dataDir string, ww WorkloadWrapper, deviceId s
 
 func NewWorkloadManagerWithParamsAndInterval(dataDir string, ww WorkloadWrapper, monitorInterval uint, deviceId string) (*WorkloadManager, error) {
 	workloadsDir := path.Join(dataDir, "workloads")
-	if err := os.MkdirAll(workloadsDir, 0750); err != nil {
+	/* #nosec */
+	if err := os.MkdirAll(workloadsDir, 0777); err != nil {
 		return nil, fmt.Errorf("cannot create directory: %w", err)
 	}
 	volumesDir := path.Join(dataDir, "volumes")
 
-	if err := os.MkdirAll(volumesDir, 0750); err != nil {
+	/* #nosec */
+	if err := os.MkdirAll(volumesDir, 0777); err != nil {
 		return nil, fmt.Errorf("cannot create directory: %w", err)
 	}
 	manager := WorkloadManager{


### PR DESCRIPTION
When rootless mode is enabled, the agent can write with user flotta, and
cannot deploy users at all.

Error discovered in the following build:

https://github.com/project-flotta/flotta-operator/runs/7169176474?check_suite_focus=true

With error:
```
2022-07-02T19:42:43.4576409Z     Jul 02 19:39:40 304de5a240b8 podman[192]: time="2022-07-02T19:39:40Z" level=info msg="Request Failed(Internal Server Error): error playing YAML file: failed to create volume \"export-nginx\": mkdir /etc/yggdrasil/device/volumes/nginx: permission denied"
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>