### PR TITLE
Propagate annotations to the pod manifest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openshift/assisted-installer-agent v1.0.10-0.20211027185717-53b0eacfa147
 	github.com/pelletier/go-toml v1.9.4
 	github.com/pkg/errors v0.9.1
-	github.com/project-flotta/flotta-operator v0.1.1-0.20220621154124-86954e9aad3a
+	github.com/project-flotta/flotta-operator v0.1.1-0.20220707151739-b925a42628d2
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/common v0.34.0
 	github.com/prometheus/prometheus v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1756,8 +1756,8 @@ github.com/pquerna/ffjson v0.0.0-20190813045741-dac163c6c0a9/go.mod h1:YARuvh7BU
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/proglottis/gpgme v0.1.1 h1:72xI0pt/hy7pqsRxk32KExITkXp+RZErRizsA+up/lQ=
 github.com/proglottis/gpgme v0.1.1/go.mod h1:fPbW/EZ0LvwQtH8Hy7eixhp1eF3G39dtx7GUN+0Gmy0=
-github.com/project-flotta/flotta-operator v0.1.1-0.20220621154124-86954e9aad3a h1:hDldH3Tyap3WKbtyY6PUrWJgo0hcLUaVDDf/FrL86uk=
-github.com/project-flotta/flotta-operator v0.1.1-0.20220621154124-86954e9aad3a/go.mod h1:Kz/l0gg1/HyJh9cuWjmLr3/syAt2vpLEOeC+BJxXt74=
+github.com/project-flotta/flotta-operator v0.1.1-0.20220707151739-b925a42628d2 h1:gLJ7bQ3V3yua1dVYEx3nXBCtJiB7c6DFSM3wxAFHsSg=
+github.com/project-flotta/flotta-operator v0.1.1-0.20220707151739-b925a42628d2/go.mod h1:Kz/l0gg1/HyJh9cuWjmLr3/syAt2vpLEOeC+BJxXt74=
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.49.0/go.mod h1:3WYi4xqXxGGXWDdQIITnLNmuDzO5n6wYva9spVhR4fg=
 github.com/prometheus/alertmanager v0.24.0/go.mod h1:r6fy/D7FRuZh5YbnX6J3MBY0eI4Pb5yPYS7/bPSXXqI=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/internal/workload/manager.go
+++ b/internal/workload/manager.go
@@ -465,6 +465,7 @@ func (w *WorkloadManager) toPod(workload *models.Workload) (*v1.Pod, error) {
 	}
 	pod.Kind = "Pod"
 	pod.Name = workload.Name
+	pod.Annotations = workload.Annotations
 	pod.Labels = workload.Labels
 	exportVolume := volumes.HostPathVolume(w.volumesDir, workload.Name)
 	pod.Spec.Volumes = append(pod.Spec.Volumes, exportVolume)

--- a/vendor/github.com/project-flotta/flotta-operator/models/workload.go
+++ b/vendor/github.com/project-flotta/flotta-operator/models/workload.go
@@ -18,6 +18,9 @@ import (
 // swagger:model workload
 type Workload struct {
 
+	// Workload Annotations
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// configmaps
 	Configmaps ConfigmapList `json:"configmaps,omitempty"`
 

--- a/vendor/github.com/project-flotta/flotta-operator/pkg/mtls/ca.go
+++ b/vendor/github.com/project-flotta/flotta-operator/pkg/mtls/ca.go
@@ -237,7 +237,7 @@ func VerifyRequest(r *http.Request, verifyType int, verifyOpts x509.VerifyOption
 		}
 
 		if _, err := cert.Verify(verifyOpts); err != nil {
-			logger.Error("Failed to verify client cert: %v", err)
+			logger.Errorf("Failed to verify client cert: %v", err)
 			return false, &ClientCertificateVerifyError{err}
 		}
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -622,7 +622,7 @@ github.com/pkg/errors
 github.com/pmezard/go-difflib/difflib
 # github.com/proglottis/gpgme v0.1.1
 github.com/proglottis/gpgme
-# github.com/project-flotta/flotta-operator v0.1.1-0.20220621154124-86954e9aad3a
+# github.com/project-flotta/flotta-operator v0.1.1-0.20220707151739-b925a42628d2
 ## explicit
 github.com/project-flotta/flotta-operator/models
 github.com/project-flotta/flotta-operator/pkg/mtls


### PR DESCRIPTION
* Bumped flotta-operator to [b925a42628d2](https://github.com/project-flotta/flotta-device-worker/commit/473da65728bca77cb391931070a5b48a358ee233)
* Added code to propagate the annotations defined in the workload to the pod manifest.