### PR TITLE
Add root label to registration test

### DIFF
--- a/internal/registration/registration_test.go
+++ b/internal/registration/registration_test.go
@@ -37,7 +37,7 @@ const (
 	deviceID         = "device-id-123"
 )
 
-var _ = Describe("Registration", func() {
+var _ = Describe("Registration", Label("root"), func() {
 
 	var (
 		datadir        string


### PR DESCRIPTION
The registration test assumes path /etc/yggdrasil is reachable and
can be written to.
For that purpose, the test should be marked with root label to be
executed with the required permissions.

Signed-off-by: Moti Asayag <masayag@redhat.com>