### PR TITLE
Fix agent installation

### DIFF
--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -82,7 +82,7 @@ func (m *Manager) RegisterObserver(observer Observer) {
 	// current config.
 	err := observer.Init(*m.deviceConfiguration)
 	if err != nil {
-		log.Error("Running config init observer failed: ", err)
+		log.Errorf("Running config init observer for '%T' failed: %v", observer, err)
 	}
 	m.observers = append(m.observers, observer)
 }
@@ -150,7 +150,7 @@ func (m *Manager) Update(message models.DeviceConfigurationMessage) error {
 	for _, observer := range m.observers {
 		err := observer.Update(message)
 		if err != nil {
-			errors = multierror.Append(errors, fmt.Errorf("running config observer failed: %s", err))
+			errors = multierror.Append(errors, fmt.Errorf("running update for observer '%T' failed: %s", observer, err))
 		}
 	}
 

--- a/internal/mount/info.go
+++ b/internal/mount/info.go
@@ -44,7 +44,7 @@ func GetMounts(dep util.IDependencies) ([]*models.Mount, map[string]*models.Moun
 	for _, entry := range entries {
 		m := parse(re, entry)
 		if m == nil {
-			log.Warnf("Cannot parse '%s'", entry)
+			log.Warnf("Cannot parse mount entry '%s'", entry)
 			continue
 		}
 

--- a/packaging/systemd/flotta-agent.service
+++ b/packaging/systemd/flotta-agent.service
@@ -7,8 +7,12 @@ Before=yggdrasild.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+# Since home directory is customed, we need to create it manually with specific selinux labels to allow access to it.
+ExecStart=bash -c "mkdir -p /var/home"
+ExecStart=bash -c "semanage fcontext -a -e /home /var/home"
+ExecStart=bash -c "restorecon -R -v /var/home"
 ExecStart=bash -c "getent group flotta >/dev/null || groupadd flotta"
-ExecStart=bash -c "getent passwd flotta >/dev/null || useradd -g flotta -s /sbin/nologin -d /var/home/flotta flotta"
+ExecStart=bash -c "getent passwd flotta >/dev/null || useradd -m -g flotta -s /sbin/nologin -b /var/home flotta"
 ExecStartPost=systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
 TimeoutSec=90s
 

--- a/packaging/systemd/flotta.conf
+++ b/packaging/systemd/flotta.conf
@@ -1,4 +1,4 @@
 F /var/lib/systemd/linger/flotta 0755 root root
+d /var/home/flotta 0777 flotta flotta -
 L /var/home/flotta/.config/systemd/user/sockets.target.wants/podman.socket 0777 flotta flotta - /usr/lib/systemd/user/podman.socket
 d /etc/yggdrasil/device/volumes 0777 flotta flotta -
-d /var/home/flotta 0777 flotta flotta -


### PR DESCRIPTION
The PR fixes errors of flotta-agent installation.
As part of the installation, flotta-agent service started and failed.
    
When selinux is enabled, post-script fails to create flotta user with error:
```
Jul 11 13:16:05 fedora useradd[3106]: new user: name=flotta, UID=1001, GID=1001, home=/var/home/flotta, shell=/sbin/nologin, from=none
Jul 11 13:16:05 fedora useradd[3106]: failed adding user 'flotta', exit code: 12
Jul 11 13:16:05 fedora bash[3106]: useradd: cannot create directory /var/home
```
   
The folder _/var/home/flotta_ requires updates to its selinux labels. To fix, we add
the label _user_home_dir_t_ to the folder  in order to serve as flotta's home directory.
    
In addition, certain flags changed for _useradd_ command to specify the base 
directory and also flag to instruct the creation of the home folder.
    