### PR TITLE
Fix: greenboot command with rootless podman

### DIFF
--- a/internal/os/greenboot_scripts.go
+++ b/internal/os/greenboot_scripts.go
@@ -9,11 +9,8 @@ grub2-editenv list | grep boot_counter >> /var/roothome/greenboot.log
 echo "----------------" >> /var/roothome/greenboot.log
 echo "" >> /var/roothome/greenboot.log`
 
-
-	GreenbootHealthCheckScript = `#!/bin/bash
-
+	GreenbootHealthCheckScript = `
 #!/bin/bash
-
 if [ -x /usr/libexec/yggdrasil/device-worker ]; then
   echo "device-worker found, check passed!"
 else
@@ -22,10 +19,13 @@ else
 fi
 
 check_is_service_active(){
+  local service=$1
+  local sudo_params=$2
+  local systemctl_params=$3
   n=0
   until [[ "$n" -ge 5 ]]
   do
-    if [[ $(systemctl is-active $1) = "active" ]]; then
+    if [[ $(sudo $sudo_params systemctl is-active $systemctl_params $service) = "active" ]]; then
       echo "$1 is active, check passed!"
       return
     else
@@ -38,12 +38,12 @@ check_is_service_active(){
   exit 1
 }
 
+params="-u flotta DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u flotta)/bus"
 
 check_is_service_active yggdrasild.service
 check_is_service_active nftables.service
-check_is_service_active podman.service
-check_is_service_active podman.socket
+check_is_service_active podman.service "$params" "--user"
+check_is_service_active podman.socket "$params" "--user"
 
 exit 0`
-
 )


### PR DESCRIPTION
When doing an upgrade using Ostree the greenboot file is added
correctly, but with the rootless podman things started to fail because
it's not correctly defined by podman.

It's using sudo instead of machinectl because it's not part of RHEL 9
default.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>