### PR TITLE
RPM: selinux added targeted context

### DIFF
--- a/packaging/file_contexts.subs
+++ b/packaging/file_contexts.subs
@@ -1,0 +1,1 @@
+/var/home /home

--- a/packaging/systemd/flotta-agent.service
+++ b/packaging/systemd/flotta-agent.service
@@ -9,8 +9,6 @@ Type=oneshot
 RemainAfterExit=yes
 # Since home directory is customed, we need to create it manually with specific selinux labels to allow access to it.
 ExecStart=bash -c "mkdir -p /var/home"
-ExecStart=bash -c "semanage fcontext -a -e /home /var/home"
-ExecStart=bash -c "restorecon -R -v /var/home"
 ExecStart=bash -c "getent group flotta >/dev/null || groupadd flotta"
 ExecStart=bash -c "getent passwd flotta >/dev/null || useradd -m -g flotta -s /sbin/nologin -b /var/home flotta"
 ExecStartPost=systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev


### PR DESCRIPTION
With this change selinux file will be added to be part of `/var/home/`
as home.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>