### PR TITLE
Fix [Errno 2] No such file or directory: '/var/lib/dnf/rpmdb_lock.pid'

### DIFF
--- a/packaging/systemd/flotta-agent.service
+++ b/packaging/systemd/flotta-agent.service
@@ -13,7 +13,7 @@ ExecStart=bash -c "semanage fcontext -a -e /home /var/home"
 ExecStart=bash -c "restorecon -R -v /var/home"
 ExecStart=bash -c "getent group flotta >/dev/null || groupadd flotta"
 ExecStart=bash -c "getent passwd flotta >/dev/null || useradd -m -g flotta -s /sbin/nologin -b /var/home flotta"
-ExecStartPost=systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
+ExecStartPost=systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev --exclude-prefix=/var/lib/dnf
 TimeoutSec=90s
 
 [Install]


### PR DESCRIPTION
Adds the exclusion of `/var/lib/dnf` from the temp file cleanup processed by `systemd-tmpfiles`. This directory contains the `rpmdb_lock.pid` file that is created during the transation in which dnf installs flotta-agent.