### PR TITLE
Systemd: Fix nologin

### DIFF
--- a/packaging/systemd/flotta-agent.service
+++ b/packaging/systemd/flotta-agent.service
@@ -13,7 +13,7 @@ ExecStart=bash -c "semanage fcontext -a -e /home /var/home || true"
 ExecStart=bash -c "restorecon -R -v /var/home || true"
 ExecStart=bash -c "getent group flotta >/dev/null || groupadd flotta"
 ExecStart=bash -c "getent passwd flotta >/dev/null || useradd -m -g flotta -s /sbin/nologin -b /var/home flotta"
-ExecStartPost=systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev --exclude-prefix=/var/lib/dnf
+ExecStartPost=systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev --exclude-prefix=/var/lib/dnf --exclude-prefix=/run/nologin
 TimeoutSec=90s
 
 [Install]


### PR DESCRIPTION
Systemd-tmpfiles set /run/nologin on
/usr/lib/tmpfiles.d/systemd-nologin.conf to booting up, with this change
/run/nologin will not be executed at all.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>