### PR TITLE
WIP:: Fix: Podman prefix with pod

### DIFF
--- a/internal/service/systemd.go
+++ b/internal/service/systemd.go
@@ -282,5 +282,5 @@ func (s *systemd) Disable() error {
 }
 
 func DefaultServiceName(serviceName string) string {
-	return serviceName + ServiceSuffix
+	return "pod-" + serviceName + ServiceSuffix
 }


### PR DESCRIPTION
With the new podman update, the systemd has a name of pod-$name.service,
so when try to create the new service it fails with the invalid name.

The log with the error:

```
Jul 19 14:16:50 localhost-live yggdrasild[3215]: [yggdrasild] 2022/07/19 14:16:50 /usr/libexec/yggdrasil/device-worker: failed to process message. DeviceID: ; err: 1 error occurred:
Jul 19 14:16:50 localhost-live yggdrasild[3215]: [yggdrasild] 2022/07/19 14:16:50 /usr/libexec/yggdrasil/device-worker:         * running update for observer '*workload.WorkloadManager' failed: 1 error occurred:
Jul 19 14:16:50 localhost-live yggdrasild[3215]: [yggdrasild] 2022/07/19 14:16:50 /usr/libexec/yggdrasil/device-worker:         * cannot run workload 'nginx-workloadb': Error while creating service: Unit file nginx-workloadb.service does not exist.
```

It's trying to use `nginx-workloadb`  instead of `pod-nginx-workladb`

```
/var/home/flotta/.config/systemd/user/container-nginx-workload-nginx-workload.service
/var/home/flotta/.config/systemd/user/pod-nginx-workload.service
/var/home/flotta/.config/systemd/user/default.target.wants/pod-nginx-workload.service
/var/home/flotta/.config/systemd/user/container-nginx-workloadb-nginx-workload.service
/var/home/flotta/.config/systemd/user/pod-nginx-workloadb.service
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>