### PR TITLE
Fix: Require podman 4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/apenella/go-ansible v1.1.5
 	github.com/armon/go-metrics v0.3.10 // indirect
 	github.com/aws/aws-sdk-go v1.44.37
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/chzyer/readline v1.5.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20211130200136-a8f946100490 // indirect
 	github.com/containers/podman/v4 v4.2.0-rc1.0.20220711193303-c57b5c9b8316

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,6 @@
-FROM quay.io/podman/stable:v4.1.0
+# FROM quay.io/podman/stable:v4.2.0
+# Hack until 4.2 is released
+FROM quay.io/podman/testing:ae7690c42379
 
 WORKDIR /project
 RUN dnf install -y 'dnf-command(copr)'

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -126,6 +126,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible
+## explicit
 github.com/blang/semver
 # github.com/cespare/xxhash/v2 v2.1.2
 github.com/cespare/xxhash/v2


### PR DESCRIPTION
Now device needs podman 4.2, so make explicit on the code.

At the moment there is no 4.2 container, so we need to use testing one.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>