### PR TITLE
Dockerfile: using flotta image

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,6 +1,6 @@
 # FROM quay.io/podman/stable:v4.2.0
 # Hack until 4.2 is released
-FROM quay.io/podman/testing:ae7690c42379
+FROM quay.io/project-flotta/podman:v4.2.0-dev
 
 WORKDIR /project
 RUN dnf install -y 'dnf-command(copr)'


### PR DESCRIPTION
The images on quay.io/podman/testing:ae7690c42379 are deleted after a
while, so I get the image and put it on project-flotta quay account

Failed CI entry:
https://github.com/project-flotta/flotta-device-worker/runs/7436420630?check_suite_focus=true

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>