### PR TITLE
Fix: systemd workload disable

### DIFF
--- a/internal/workload/wrapper.go
+++ b/internal/workload/wrapper.go
@@ -275,9 +275,14 @@ func (ww *Workload) removeService(workloadName string) error {
 	// Ignore stop failure:
 	_ = svc.Stop()
 
+	// Disable the service from the system:
+	if err := svc.Disable(); err != nil {
+		return fmt.Errorf("Cannot disable systemd service for '%s': %s", workloadName, err)
+	}
+
 	// Remove the service from the system:
 	if err := svc.Remove(); err != nil {
-		return err
+		return fmt.Errorf("Cannot remove systemd service for '%s': %s", workloadName, err)
 	}
 
 	err := ww.serviceManager.Remove(svc)


### PR DESCRIPTION
When running on systemd some leftovers are on
`/var/home/flotta/.config/systemd/user/default.target.wants/` mainly
because service is deleted, but the symlink is not deleted at all.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>