### PR TITLE
RPM: fix podman version dependency

### DIFF
--- a/flotta-agent.spec
+++ b/flotta-agent.spec
@@ -26,7 +26,7 @@ Requires:       ansible
 %endif
 Requires:       nftables
 Requires:       node_exporter
-Requires:       podman >= 4.2.0
+Requires:       podman >= 4:4.2.0
 Requires:       yggdrasil
 
 Requires(pre): shadow-utils


### PR DESCRIPTION
The version is in a different format, example of build:

```
%define _build_id_links none
%global flotta_systemd packaging/systemd
%global flotta_user flotta

Name:       eloy
Version:    0.2.0
Release:    3%{?dist}
Summary:    Agent application for the Flotta Edge Management solution
ExclusiveArch: %{go_arches}
Group:      Flotta
License:    ASL 2.0

Requires:       podman >= 4:4.2.0

Provides:       %{name} = %{version}-%{release}
Provides:       golang(%{go_import_path}) = %{version}-%{release}

%description
eloy

%prep
ls

%build
touch test.txt

%install
mkdir -p %{buildroot}/var/log/
cp test.txt  %{buildroot}/var/log/

%files
/var/log/test.txt

%changelog

* Tue Jul 26 2022 Eloy Coto <eloycoto@acalustra.com> 0.2.0-3
- Fix containers startup on systemd

* Tue Jul 26 2022 Moti Asayag <masayag@redhat.com> 0.2.0-2
- Start containers by systemd to be owned by flotta user
- Propogate annotations to to podman's kube struct

* Thu Jul 14 2022 Moti Asayag <masayag@redhat.com> 0.2.0-1
- Added support for rootless podman
- Added support for host devices

* Thu Jun 23 2022 Jordi Gil <jgil@redhat.com> 0.1.0-3
  Added missing '-race' to go build command for race package

* Wed Jun 22 2022 Eloy Coto <eloycoto@acalustra.com> 0.1.0-2
  Changes on systemd config

* Thu May 12 2022 Ondra Machacek <omachace@redhat.com> 0.1.0-1
- Initial release.
```

```
[root@409dea99402f opt]# rpm -qpR /root/rpmbuild/RPMS/x86_64/eloy-0.2.0-3.fc36.x86_64.rpm
podman >= 4:4.2.0
rpmlib(CompressedFileNames) <= 3.0.4-1
rpmlib(FileDigests) <= 4.6.0-1
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(PayloadIsZstd) <= 5.4.18-1
[root@409dea99402f opt]# rpm -qa | grep podman
podman-gvproxy-4.1.1-3.fc36.x86_64
podman-4.1.1-3.fc36.x86_64
[root@409dea99402f opt]# rpm -i /root/rpmbuild/RPMS/x86_64/eloy-0.2.0-3.fc36.x86_64.rpm
error: Failed dependencies:
        podman >= 4:4.2.0 is needed by eloy-0.2.0-3.fc36.x86_64
[root@409dea99402f opt]#
```

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>