### PR TITLE
Upgrade podman image version to v4.2.0-rc3

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,21 +1,26 @@
 # FROM quay.io/podman/stable:v4.2.0
 # Hack until 4.2 is released
-FROM quay.io/project-flotta/podman:v4.2.0-dev
+FROM quay.io/project-flotta/podman:v4.2.0-rc3-dev
 
 WORKDIR /project
 RUN dnf install -y 'dnf-command(copr)'
 RUN dnf copr enable project-flotta/flotta-testing -y
 
 # Yum dependencies
-RUN dnf update -y \
+RUN dnf update -y --exclude podman \
   && dnf install -y openssl procps-ng dmidecode nc iproute \
   yggdrasil flotta-agent-race node_exporter systemd-container \
   libselinux-utils util-linux sssd-client
 
 # Modify podman configuration
-RUN sed -i s/netns=\"host\"/netns=\"private\"/g /etc/containers/containers.conf && \
-    sed -i s/utsns=\"host\"/utsns=\"private\"/g /etc/containers/containers.conf && \
-    sed -i s/ipcns=\"host\"/ipcns=\"private\"/g /etc/containers/containers.conf
+RUN sed -i 's/netns = \"host\"/netns = \"private\"/g' /usr/share/containers/containers.conf && \
+    sed -i 's/utsns = \"host\"/utsns = \"private\"/g' /usr/share/containers/containers.conf && \
+    sed -i 's/ipcns = \"shareable\"/ipcns = \"private\"/g' /usr/share/containers/containers.conf
+
+# Uncomment podman configuration
+RUN sed -i '/netns = \"private\"/s/^#//g' /usr/share/containers/containers.conf && \
+    sed -i '/utsns = \"private\"/s/^#//g' /usr/share/containers/containers.conf && \
+    sed -i '/ipcns = \"private\"/s/^#//g' /usr/share/containers/containers.conf
 
 # Certificate reqs:
 RUN mkdir /etc/pki/consumer && \


### PR DESCRIPTION
Updated edgedevice image to use podman v4.2.0-rc3.
Build of base image done by using the following Dockerfile:
```
FROM quay.io/podman/upstream:latest
RUN dnf -y remove podman
RUN dnf -y install --best podman --enablerepo=updates-testing --disablerepo=copr:copr.fedorainfracloud.org:rhcontainerbot:podman-next
```
Image pushed to quay.io/project-flotta/podman:v4.2.0-rc3-dev

Changes were made to edgedevice Dockerfile since the configuration file located in a different location and few tweaks were needed.

Signed-off-by: Moti Asayag <masayag@redhat.com>